### PR TITLE
fix: Make tests compile without `--all-features` and fix unused warnings

### DIFF
--- a/samod/Cargo.toml
+++ b/samod/Cargo.toml
@@ -48,6 +48,7 @@ tokio = { version = "1.46.0", features = [
     "fs",
 ] }
 tokio-stream = { version = "0.1.17", features = ["io-util"] }
+tokio-util = { version = "0.7.15", features = ["codec", "net"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [[test]]

--- a/samod/src/storage/filesystem.rs
+++ b/samod/src/storage/filesystem.rs
@@ -1,9 +1,6 @@
-use std::path::PathBuf;
-
-use samod_core::StorageKey;
-
-pub fn key_to_path(key: &StorageKey) -> PathBuf {
-    let mut result = PathBuf::new();
+#[cfg(any(feature = "tokio", feature = "gio"))]
+pub fn key_to_path(key: &samod_core::StorageKey) -> std::path::PathBuf {
+    let mut result = std::path::PathBuf::new();
     for (index, component) in key.into_iter().enumerate() {
         // splay the first key out by the first two characters
         if index == 0 {


### PR DESCRIPTION
Without `tokio-utils` in the `dev-dependencies`, I'm getting this with `cargo test`:
```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `tokio_util`
 --> samod/tests/tincans.rs:6:5
  |
6 | use tokio_util::sync::{CancellationToken, PollSender};
  |     ^^^^^^^^^^ use of unresolved module or unlinked crate `tokio_util`
  |
  = help: if you wanted to use a crate named `tokio_util`, use `cargo add tokio_util` to add it to your `Cargo.toml`
```