### PR TITLE
refactor(samod, samod-core): Refactor all uses of `Rc`/`RefCell` with `Arc`/`Mutex`

### DIFF
--- a/samod-core/src/actors/document/run.rs
+++ b/samod-core/src/actors/document/run.rs
@@ -1,8 +1,9 @@
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
-
-use futures::{
-    FutureExt, StreamExt, channel::mpsc, future::LocalBoxFuture, stream::FuturesUnordered,
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
 };
+
+use futures::{FutureExt, StreamExt, channel::mpsc, future::BoxFuture, stream::FuturesUnordered};
 
 use crate::{
     ConnectionId, PeerId, StorageKey, UnixTimestamp,
@@ -30,29 +31,32 @@ use super::{ActorIoAccess, ActorState};
 
 /// The main async runtime loop for the document actor.
 pub async fn actor_run(
-    now: Rc<RefCell<UnixTimestamp>>,
+    now: Arc<Mutex<UnixTimestamp>>,
     mut rx_input: mpsc::UnboundedReceiver<ActorInput>,
     io: ActorIo<DocumentActor>,
-    state: Rc<RefCell<ActorState>>,
+    state: Arc<Mutex<ActorState>>,
     initial_connections: HashMap<ConnectionId, (PeerId, Option<DocMessage>)>,
 ) {
     tracing::trace!(?initial_connections, "applying initial connections");
     let io = ActorIoAccess::new(io);
     for (conn_id, (peer_id, msg)) in initial_connections {
-        state.borrow_mut().add_connection(conn_id, peer_id);
+        state.lock().unwrap().add_connection(conn_id, peer_id);
         if let Some(msg) = msg {
-            state
-                .borrow_mut()
-                .handle_doc_message(*now.borrow(), io.clone(), conn_id, msg);
+            state.lock().unwrap().handle_doc_message(
+                *now.lock().unwrap(),
+                io.clone(),
+                conn_id,
+                msg,
+            );
         }
     }
 
     // Collection of futures representing operations that are currently executing
     let mut running_operations = FuturesUnordered::new();
 
-    if state.borrow().is_loading() {
+    if state.lock().unwrap().is_loading() {
         tracing::trace!("starting new loading doc actor");
-        running_operations.push(load(io.clone(), state.clone(), now.clone()).boxed_local());
+        running_operations.push(load(io.clone(), state.clone(), now.clone()).boxed());
     } else {
         tracing::debug!("document actor is ready immediately");
         io.send_message(DocToHubMsgPayload::DocumentStatusChanged {
@@ -61,7 +65,7 @@ pub async fn actor_run(
     }
 
     loop {
-        if state.borrow().run_state() == RunState::Stopping {
+        if state.lock().unwrap().run_state() == RunState::Stopping {
             tracing::debug!("Document actor is stopping, exiting runtime loop");
             // Exit the runtime loop if the actor is stopping
             break;
@@ -74,14 +78,14 @@ pub async fn actor_run(
             input = rx_input.select_next_some() => {
                 if matches!(input, ActorInput::Terminate) {
                     tracing::debug!("terminating document actor");
-                    state.borrow_mut().set_run_state(RunState::Stopping);
+                    state.lock().unwrap().set_run_state(RunState::Stopping);
                     // Exit the runtime loop after receiving a termination signal
                     break;
                 }
                 let state_clone = state.clone();
                 let io_clone = io.clone();
                 let operation_future = handle_input(now.clone(), state_clone, io_clone, input);
-                running_operations.push(operation_future.boxed_local());
+                running_operations.push(operation_future.boxed());
             }
             operation_result = running_operations.select_next_some() => {
                 // Handle completed operation
@@ -97,18 +101,22 @@ pub async fn actor_run(
         continue;
     }
     io.send_message(DocToHubMsgPayload::Terminated);
-    state.borrow_mut().set_run_state(RunState::Stopped);
+    state.lock().unwrap().set_run_state(RunState::Stopped);
     tracing::debug!("document actor runtime loop exited cleanly");
 }
 
 fn generate_sync_messages(
     io: ActorIoAccess,
-    state: Rc<RefCell<ActorState>>,
-    now: Rc<RefCell<UnixTimestamp>>,
+    state: Arc<Mutex<ActorState>>,
+    now: Arc<Mutex<UnixTimestamp>>,
 ) {
     // Something happened, make sure we send any sync messages we need to send
-    let doc_id = state.borrow().document_id.clone();
-    for (conn_id, msgs) in state.borrow_mut().generate_sync_messages(*now.borrow()) {
+    let doc_id = state.lock().unwrap().document_id.clone();
+    for (conn_id, msgs) in state
+        .lock()
+        .unwrap()
+        .generate_sync_messages(*now.lock().unwrap())
+    {
         for msg in msgs {
             io.send_message(DocToHubMsgPayload::SendSyncMessage {
                 connection_id: conn_id,
@@ -121,11 +129,11 @@ fn generate_sync_messages(
 
 fn save_new_changes(
     io: ActorIoAccess,
-    state: Rc<RefCell<ActorState>>,
-    running_operations: &mut FuturesUnordered<LocalBoxFuture<'static, Result<(), DocumentError>>>,
+    state: Arc<Mutex<ActorState>>,
+    running_operations: &mut FuturesUnordered<BoxFuture<'static, Result<(), DocumentError>>>,
 ) {
     // Make sure we save any new changes
-    let new_jobs = state.borrow_mut().pop_new_jobs();
+    let new_jobs = state.lock().unwrap().pop_new_jobs();
     if !new_jobs.is_empty() {
         for job in new_jobs {
             let io = io.clone();
@@ -142,10 +150,10 @@ fn save_new_changes(
                             JobComplete::Delete(storage_key)
                         }
                     };
-                    state.borrow_mut().mark_job_complete(result);
+                    state.lock().unwrap().mark_job_complete(result);
                     Ok(())
                 }
-                .boxed_local(),
+                .boxed(),
             );
         }
     }
@@ -153,10 +161,10 @@ fn save_new_changes(
 
 fn enqueue_announce_policy_checks(
     io: ActorIoAccess,
-    state: Rc<RefCell<ActorState>>,
-    running_operations: &mut FuturesUnordered<LocalBoxFuture<'static, Result<(), DocumentError>>>,
+    state: Arc<Mutex<ActorState>>,
+    running_operations: &mut FuturesUnordered<BoxFuture<'static, Result<(), DocumentError>>>,
 ) {
-    let check_policy_tasks = state.borrow_mut().pop_announce_policy_tasks();
+    let check_policy_tasks = state.lock().unwrap().pop_announce_policy_tasks();
     for (peer_id, conn_id) in check_policy_tasks {
         tracing::trace!(?peer_id, ?conn_id, "checking announce policy");
         running_operations.push({
@@ -172,10 +180,11 @@ fn enqueue_announce_policy_checks(
                 );
                 if should_announce {
                     state
-                        .borrow_mut()
+                        .lock()
+                        .unwrap()
                         .set_announce_policy(io, conn_id, AnnouncePolicy::Announce)
                 } else {
-                    state.borrow_mut().set_announce_policy(
+                    state.lock().unwrap().set_announce_policy(
                         io,
                         conn_id,
                         AnnouncePolicy::DontAnnounce,
@@ -183,7 +192,7 @@ fn enqueue_announce_policy_checks(
                 }
                 Ok::<_, DocumentError>(())
             }
-            .boxed_local()
+            .boxed()
         })
     }
 }
@@ -194,8 +203,8 @@ fn enqueue_announce_policy_checks(
 /// handlers, providing a clean separation between message routing and
 /// operation implementation.
 async fn handle_input(
-    now: Rc<RefCell<UnixTimestamp>>,
-    state: Rc<RefCell<ActorState>>,
+    now: Arc<Mutex<UnixTimestamp>>,
+    state: Arc<Mutex<ActorState>>,
     io: ActorIoAccess,
     input: ActorInput,
 ) -> Result<(), DocumentError> {
@@ -209,8 +218,8 @@ async fn handle_input(
             connection_id,
             message,
         } => {
-            state.borrow_mut().handle_doc_message(
-                *now.borrow(),
+            state.lock().unwrap().handle_doc_message(
+                *now.lock().unwrap(),
                 io.clone(),
                 connection_id,
                 message,
@@ -220,10 +229,10 @@ async fn handle_input(
             connection_id,
             peer_id,
         } => {
-            state.borrow_mut().add_connection(connection_id, peer_id);
+            state.lock().unwrap().add_connection(connection_id, peer_id);
         }
         ActorInput::ConnectionClosed { connection_id } => {
-            state.borrow_mut().remove_connection(connection_id);
+            state.lock().unwrap().remove_connection(connection_id);
         }
         ActorInput::Request => {
             load(io.clone(), state, now).await?;
@@ -235,13 +244,13 @@ async fn handle_input(
 
 async fn load(
     io: ActorIoAccess,
-    state: Rc<RefCell<ActorState>>,
-    now: Rc<RefCell<UnixTimestamp>>,
+    state: Arc<Mutex<ActorState>>,
+    now: Arc<Mutex<UnixTimestamp>>,
 ) -> Result<(), DocumentError> {
-    state.borrow_mut().ensure_request(io.clone());
+    state.lock().unwrap().ensure_request(io.clone());
     tracing::debug!("loading document from storage");
     let io = io.clone();
-    let doc_id = state.borrow().document_id.clone();
+    let doc_id = state.lock().unwrap().document_id.clone();
 
     let snapshot_prefix = StorageKey::from(vec![doc_id.to_string(), "snapshot".to_string()]);
     let snapshots = io.load_range(snapshot_prefix).await;
@@ -250,7 +259,8 @@ async fn load(
     let incrementals = io.load_range(incremental_prefix).await;
 
     state
-        .borrow_mut()
-        .handle_load(*now.borrow(), io.clone(), snapshots, incrementals);
+        .lock()
+        .unwrap()
+        .handle_load(*now.lock().unwrap(), io.clone(), snapshots, incrementals);
     Ok(())
 }

--- a/samod-core/src/actors/driver.rs
+++ b/samod-core/src/actors/driver.rs
@@ -11,7 +11,7 @@ use crate::{
     io::{IoResult, IoTask, IoTaskId},
 };
 
-use super::executor::LocalExecutor;
+use super::executor::Executor;
 
 pub(crate) trait Actor {
     type IoTaskAction: Debug;
@@ -32,7 +32,7 @@ pub(crate) struct Driver<A: Actor> {
     io_tasks: HashMap<IoTaskId, oneshot::Sender<A::IoResult>>,
     rx_output: mpsc::UnboundedReceiver<DriverOutput<A>>,
     tx_input: mpsc::UnboundedSender<A::Input>,
-    executor: LocalExecutor<A::Complete>,
+    executor: Executor<A::Complete>,
 }
 
 pub(crate) struct SpawnArgs<A: Actor> {
@@ -82,7 +82,7 @@ impl<A: Actor> Driver<A> {
             rx_input,
             now: now.clone(),
         });
-        let executor = LocalExecutor::spawn(future);
+        let executor = Executor::spawn(future);
         Self {
             now,
             io_tasks: HashMap::new(),

--- a/samod-core/src/actors/executor.rs
+++ b/samod-core/src/actors/executor.rs
@@ -10,7 +10,7 @@ use futures::{
 };
 
 /// A very simple "executor" which just drives a single future.
-pub(crate) struct LocalExecutor<T> {
+pub(crate) struct Executor<T> {
     running: Option<FutureObj<'static, T>>,
 }
 
@@ -26,8 +26,8 @@ impl ArcWake for WakeThis {
     }
 }
 
-impl<T> LocalExecutor<T> {
-    /// Create a new `LocalExecutor` which will  drive the given Future until completion
+impl<T> Executor<T> {
+    /// Create a new [`Executor`] which will  drive the given Future until completion
     pub(crate) fn spawn<Fut: Future<Output = T> + Send + 'static>(fut: Fut) -> Self {
         let fut_obj = FutureObj::new(Box::new(fut));
         Self {

--- a/samod-core/src/actors/executor.rs
+++ b/samod-core/src/actors/executor.rs
@@ -6,12 +6,12 @@ use std::{
 
 use futures::{
     FutureExt,
-    task::{ArcWake, LocalFutureObj, waker},
+    task::{ArcWake, FutureObj, waker},
 };
 
 /// A very simple "executor" which just drives a single future.
 pub(crate) struct LocalExecutor<T> {
-    running: Option<LocalFutureObj<'static, T>>,
+    running: Option<FutureObj<'static, T>>,
 }
 
 struct WakeThis {
@@ -28,8 +28,8 @@ impl ArcWake for WakeThis {
 
 impl<T> LocalExecutor<T> {
     /// Create a new `LocalExecutor` which will  drive the given Future until completion
-    pub(crate) fn spawn<Fut: Future<Output = T> + 'static>(fut: Fut) -> Self {
-        let fut_obj = LocalFutureObj::new(Box::new(fut));
+    pub(crate) fn spawn<Fut: Future<Output = T> + Send + 'static>(fut: Fut) -> Self {
+        let fut_obj = FutureObj::new(Box::new(fut));
         Self {
             running: Some(fut_obj),
         }

--- a/samod-core/src/actors/hub/command_handlers.rs
+++ b/samod-core/src/actors/hub/command_handlers.rs
@@ -15,7 +15,7 @@ use futures::channel::oneshot;
 
 use super::{Command, CommandId, CommandResult, task_context::TaskContext};
 
-pub(crate) async fn handle_command<R: rand::Rng + Clone>(
+pub(crate) async fn handle_command<R: rand::Rng + Send + Clone>(
     ctx: TaskContext<R>,
     command_id: CommandId,
     command: Command,
@@ -36,7 +36,7 @@ pub(crate) async fn handle_command<R: rand::Rng + Clone>(
     }
 }
 
-async fn handle_create_connection<R: rand::Rng + Clone>(
+async fn handle_create_connection<R: rand::Rng + Send + Clone>(
     ctx: TaskContext<R>,
     direction: ConnDirection,
 ) -> CommandResult {
@@ -62,7 +62,7 @@ async fn handle_create_connection<R: rand::Rng + Clone>(
     CommandResult::CreateConnection { connection_id }
 }
 
-async fn handle_receive<R: rand::Rng + Clone>(
+async fn handle_receive<R: rand::Rng + Send + Clone>(
     ctx: TaskContext<R>,
     connection_id: ConnectionId,
     msg: Vec<u8>,
@@ -160,7 +160,7 @@ async fn handle_receive<R: rand::Rng + Clone>(
     }
 }
 
-async fn handle_doc_message<R: rand::Rng + Clone>(
+async fn handle_doc_message<R: rand::Rng + Send + Clone>(
     ctx: TaskContext<R>,
     connection_id: ConnectionId,
     target_id: PeerId,
@@ -188,7 +188,7 @@ async fn handle_doc_message<R: rand::Rng + Clone>(
 }
 
 #[tracing::instrument(skip(ctx, init_doc), fields(command_id = %command_id))]
-async fn handle_create_document<R: rand::Rng + Clone>(
+async fn handle_create_document<R: rand::Rng + Send + Clone>(
     mut ctx: TaskContext<R>,
     command_id: CommandId,
     init_doc: Automerge,
@@ -215,7 +215,7 @@ async fn handle_create_document<R: rand::Rng + Clone>(
 }
 
 #[tracing::instrument(skip(ctx), fields(document_id = %document_id))]
-async fn handle_find_document<R: rand::Rng + Clone>(
+async fn handle_find_document<R: rand::Rng + Send + Clone>(
     ctx: TaskContext<R>,
     command_id: CommandId,
     document_id: DocumentId,
@@ -273,7 +273,7 @@ async fn handle_find_document<R: rand::Rng + Clone>(
     })
 }
 
-async fn spawn_actor<R: rand::Rng + Clone>(
+async fn spawn_actor<R: rand::Rng + Send + Clone>(
     ctx: TaskContext<R>,
     document_id: DocumentId,
     initial_doc: Option<Automerge>,

--- a/samod-core/src/actors/hub/run.rs
+++ b/samod-core/src/actors/hub/run.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc};
+use std::sync::{Arc, Mutex};
 
 use futures::{StreamExt, channel::mpsc, stream::FuturesUnordered};
 
@@ -20,10 +20,10 @@ pub(crate) use hub_input::HubInput;
 mod hub_output;
 pub(crate) use hub_output::HubOutput;
 
-pub(crate) async fn run<R: rand::Rng + Clone + 'static>(
+pub(crate) async fn run<R: rand::Rng + Send + Clone + 'static>(
     rng: R,
-    now: Rc<RefCell<UnixTimestamp>>,
-    state: Rc<RefCell<State>>,
+    now: Arc<Mutex<UnixTimestamp>>,
+    state: Arc<Mutex<State>>,
     mut rx_input: mpsc::UnboundedReceiver<HubInput>,
     io: ActorIo<Hub>,
 ) {
@@ -187,5 +187,5 @@ pub(crate) async fn run<R: rand::Rng + Clone + 'static>(
         }
     }
 
-    state.borrow_mut().set_run_state(RunState::Stopped);
+    state.lock().unwrap().set_run_state(RunState::Stopped);
 }

--- a/samod-core/src/actors/hub/task_context/conn_access.rs
+++ b/samod-core/src/actors/hub/task_context/conn_access.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc};
+use std::sync::{Arc, Mutex};
 
 use crate::{
     ConnectionId, UnixTimestamp,
@@ -11,13 +11,13 @@ use super::IoAccess;
 pub(crate) struct ConnectionAccess<'a> {
     pub(super) now: UnixTimestamp,
     pub(super) io: IoAccess,
-    pub(super) state: &'a Rc<RefCell<State>>,
+    pub(super) state: &'a Arc<Mutex<State>>,
     pub(super) conn_id: ConnectionId,
 }
 
 impl ConnectionAccess<'_> {
     pub(crate) fn receive(&self, msg: WireMessage) -> Vec<ReceiveEvent> {
-        let mut state = self.state.borrow_mut();
+        let mut state = self.state.lock().unwrap();
         let conn = state.get_connection_mut(&self.conn_id).unwrap();
         conn.receive_msg(self.io.clone(), self.now, msg)
     }

--- a/samod-core/src/loader.rs
+++ b/samod-core/src/loader.rs
@@ -20,8 +20,10 @@ use crate::{
 ///
 /// ```rust,no_run
 /// use samod_core::{PeerId, SamodLoader, LoaderState, UnixTimestamp, io::{StorageResult, IoResult}};
+/// use rand::SeedableRng;
 ///
-/// let mut loader = SamodLoader::new(rand::rng(), PeerId::from("test"), UnixTimestamp::now());
+/// let rng = rand::rngs::StdRng::from_rng(&mut rand::rng());
+/// let mut loader = SamodLoader::new(rng, PeerId::from("test"), UnixTimestamp::now());
 ///
 /// loop {
 ///     match loader.step(UnixTimestamp::now()) {

--- a/samod-core/src/loader.rs
+++ b/samod-core/src/loader.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc};
+use std::sync::{Arc, Mutex};
 
 use crate::{
     PeerId, UnixTimestamp,
@@ -56,7 +56,7 @@ pub enum LoaderState {
     Loaded(Hub),
 }
 
-impl<R: rand::Rng + Clone + 'static> SamodLoader<R> {
+impl<R: rand::Rng + Clone + Send + Sync + 'static> SamodLoader<R> {
     /// Creates a new samod loader.
     ///
     /// # Arguments
@@ -93,7 +93,7 @@ impl<R: rand::Rng + Clone + 'static> SamodLoader<R> {
                 complete: (hub_state, rng),
             } => {
                 assert!(results.is_empty());
-                let state = Rc::new(RefCell::new(hub_state));
+                let state = Arc::new(Mutex::new(hub_state));
                 let hub = Hub::new(rng, now, state);
                 return LoaderState::Loaded(hub);
             }

--- a/samod-test-harness/src/samod_wrapper.rs
+++ b/samod-test-harness/src/samod_wrapper.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use automerge::Automerge;
-use rand::rand_core::UnwrapErr;
+use rand::SeedableRng;
 use samod_core::{
     CommandId, CommandResult, ConnectionId, DocumentActorId, DocumentChanged, DocumentId, PeerId,
     StorageId, StorageKey, UnixTimestamp,
@@ -49,7 +49,7 @@ impl SamodWrapper {
     pub fn new_with_storage(nickname: String, mut storage: Storage) -> Self {
         let peer_id = PeerId::from_string(nickname.clone());
         let mut loader = samod_core::SamodLoader::new(
-            UnwrapErr(rand::rngs::OsRng),
+            rand::rngs::StdRng::from_rng(&mut rand::rng()),
             peer_id,
             UnixTimestamp::now(),
         );

--- a/samod-test-harness/src/samod_wrapper.rs
+++ b/samod-test-harness/src/samod_wrapper.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use automerge::Automerge;
+use rand::rand_core::UnwrapErr;
 use samod_core::{
     CommandId, CommandResult, ConnectionId, DocumentActorId, DocumentChanged, DocumentId, PeerId,
     StorageId, StorageKey, UnixTimestamp,
@@ -47,7 +48,11 @@ impl SamodWrapper {
 
     pub fn new_with_storage(nickname: String, mut storage: Storage) -> Self {
         let peer_id = PeerId::from_string(nickname.clone());
-        let mut loader = samod_core::SamodLoader::new(rand::rng(), peer_id, UnixTimestamp::now());
+        let mut loader = samod_core::SamodLoader::new(
+            UnwrapErr(rand::rngs::OsRng),
+            peer_id,
+            UnixTimestamp::now(),
+        );
         let now = UnixTimestamp::now();
 
         // Execute the loading process
@@ -93,9 +98,9 @@ impl SamodWrapper {
             .expect("The create connection command never completed");
         match completed_command {
             CommandResult::CreateConnection { connection_id, .. } => connection_id,
-            _ => panic!(
-                "Expected a CreateConnection command result, but got {completed_command:?}"
-            ),
+            _ => {
+                panic!("Expected a CreateConnection command result, but got {completed_command:?}")
+            }
         }
     }
 
@@ -110,9 +115,9 @@ impl SamodWrapper {
             .expect("The create incoming connection command never completed");
         match completed_command {
             CommandResult::CreateConnection { connection_id, .. } => connection_id,
-            _ => panic!(
-                "Expected a CreateConnection command result, but got {completed_command:?}"
-            ),
+            _ => {
+                panic!("Expected a CreateConnection command result, but got {completed_command:?}")
+            }
         }
     }
 
@@ -132,9 +137,7 @@ impl SamodWrapper {
                 doc_id: document_id,
                 actor_id,
             },
-            _ => panic!(
-                "Expected a CreateDocument command result, but got {completed_command:?}"
-            ),
+            _ => panic!("Expected a CreateDocument command result, but got {completed_command:?}"),
         }
     }
 
@@ -180,9 +183,9 @@ impl SamodWrapper {
                 CommandResult::FindDocument { found, actor_id } => {
                     Some(if found { Some(actor_id) } else { None })
                 }
-                _ => panic!(
-                    "Expected a FindDocument command result, but got {completed_command:?}"
-                ),
+                _ => {
+                    panic!("Expected a FindDocument command result, but got {completed_command:?}")
+                }
             }
         } else {
             None // Command not yet completed

--- a/samod/src/lib.rs
+++ b/samod/src/lib.rs
@@ -10,7 +10,7 @@ use futures::{
     channel::{mpsc, oneshot},
     stream::FuturesUnordered,
 };
-use rand::rand_core::UnwrapErr;
+use rand::SeedableRng;
 use samod_core::{
     CommandId, CommandResult, ConnectionId, DocumentActorId, LoaderState, UnixTimestamp,
     actors::{
@@ -91,7 +91,7 @@ impl Samod {
             peer_id,
             announce_policy,
         } = builder;
-        let mut rng = UnwrapErr(rand::rngs::OsRng);
+        let mut rng = rand::rngs::StdRng::from_rng(&mut rand::rng());
         let peer_id = peer_id.unwrap_or_else(|| PeerId::new_with_rng(&mut rng));
         let mut loading = Hub::load(rng, UnixTimestamp::now(), peer_id.clone());
         let mut running_tasks = FuturesUnordered::new();


### PR DESCRIPTION
Replaces all usage of `Rc` & `RefCell` with `Arc` and `Mutex`.
This makes `SamodBuilder::load` return a future that is `Send`, and we don't need to `unsafe impl Send for` things anymore.

Also adds a (compile time) test to make sure that `load` returns a future that is `Send`.

Fixes #1 