### PR TITLE
fix: Prevent trying to re-enter state lock in instrument macro

### DIFF
--- a/samod-core/src/actors/document/actor.rs
+++ b/samod-core/src/actors/document/actor.rs
@@ -13,7 +13,7 @@ use crate::actors::driver::{Actor, Driver, StepResult};
 use crate::actors::messages::{Broadcast, DocToHubMsgPayload};
 use crate::actors::{DocToHubMsg, HubToDocMsg, RunState};
 use crate::io::{IoResult, IoTask};
-use crate::{DocumentActorId, DocumentChanged, DocumentId, UnixTimestamp};
+use crate::{DocumentActorId, DocumentChanged, DocumentId, PeerId, UnixTimestamp};
 
 use super::{actor_state::ActorState, errors::DocumentError, run::ActorInput};
 
@@ -127,8 +127,8 @@ impl DocumentActor {
     #[tracing::instrument(
         skip(self, io_result),
         fields(
-            local_peer_id=%self.state.lock().unwrap().local_peer_id(),
-            document_id=%self.state.lock().unwrap().document_id,
+            local_peer_id=%self.local_peer_id(),
+            document_id=%self.document_id,
             actor_id=%self.id
         )
     )]
@@ -144,6 +144,10 @@ impl DocumentActor {
     /// Returns the document ID this actor manages.
     pub fn document_id(&self) -> &DocumentId {
         &self.document_id
+    }
+
+    fn local_peer_id(&self) -> PeerId {
+        self.state.lock().unwrap().local_peer_id().clone()
     }
 
     /// Provides mutable access to the document with automatic side effect handling.


### PR DESCRIPTION
This one was maybe a little painful.

Without this fix, I'm getting a deadlock with the following test:

```rs
#[tokio::test]
async fn test_find() -> Result<()> {
    const TEST_DOCUMENT_ID: &str = "2ZiqrTNH7ReMNQxNnDy3e1pvt31D";
    const TEST_STORAGE_KEY: &[&str] = &[
        TEST_DOCUMENT_ID,
        "incremental",
        "35328779586cc60cf02b1ed124e38b58b65c1ce191bb6da2b51d7358150cbfd4",
    ];
    const TEST_STORAGE_VALUE: &[u8] = &[
        133, 111, 74, 131, 53, 50, 135, 121, 1, 24, 0, 16, 177, 240, 204, 48, 224, 65, 72, 26, 160,
        183, 93, 153, 175, 242, 233, 191, 1, 1, 0, 0, 0, 0,
    ];

    let storage = InMemoryStorage::new();
    storage
        .put(
            StorageKey::from_parts(TEST_STORAGE_KEY),
            TEST_STORAGE_VALUE.to_vec(),
        )
        .await;
    let repo = Samod::build_tokio().with_storage(storage).load().await;

    let doc_id = DocumentId::from_str(TEST_DOCUMENT_ID).expect("hardcoded");
    let doc = timeout(Duration::from_secs(5), repo.find(doc_id))
        .await??
        .expect("no doc found");

    println!("Found doc: {:?}", doc.document_id());

    Ok(())
}
```

This test hits `repo.find(doc_id)` timing out after 5 seconds for me.