### PR TITLE
samod: Switch to doc_auto_cfg

### DIFF
--- a/samod/src/lib.rs
+++ b/samod/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 //! # Samod
 //!
 //! `samod` is a library for building collaborative applications which work offlne
@@ -342,7 +342,6 @@ impl Repo {
     /// ## Panics
     /// If called outside of the dynamic scope of a tokio runtime
     #[cfg(feature = "tokio")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
     pub fn build_tokio() -> RepoBuilder<InMemoryStorage, ::tokio::runtime::Handle, AlwaysAnnounce> {
         builder::RepoBuilder::new(::tokio::runtime::Handle::current())
     }
@@ -362,7 +361,6 @@ impl Repo {
     ///
     /// This function will panic if called outside of a gio mainloop context.
     #[cfg(feature = "gio")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "gio")))]
     pub fn build_gio()
     -> RepoBuilder<InMemoryStorage, crate::runtime::gio::GioRuntime, AlwaysAnnounce> {
         builder::RepoBuilder::new(crate::runtime::gio::GioRuntime::new())
@@ -560,7 +558,6 @@ impl Repo {
     /// # }
     /// ```
     #[cfg(feature = "tokio")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
     pub fn connect_tokio_io<Io: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + 'static>(
         &self,
         io: Io,

--- a/samod/src/runtime/gio.rs
+++ b/samod/src/runtime/gio.rs
@@ -6,7 +6,6 @@ use futures::FutureExt;
 /// A [`RuntimeHandle`](crate::runtime::RuntimeHandle) implementation which usese the `glib` crate to spawn tasks
 ///
 /// This runtime will panic if used outside of a `glib` main loop context
-#[cfg_attr(docsrs, doc(cfg(feature = "gio")))]
 #[derive(Clone, Debug)]
 pub struct GioRuntime;
 
@@ -36,7 +35,6 @@ impl crate::runtime::RuntimeHandle for GioRuntime {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "gio")))]
 pub struct GlibJoinError(glib::JoinError);
 
 impl std::fmt::Display for GlibJoinError {
@@ -63,7 +61,6 @@ impl JoinError for GlibJoinError {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "gio")))]
 pub struct GlibJoinHandle<O>(glib::JoinHandle<O>);
 
 impl<O: 'static> Future for GlibJoinHandle<O> {

--- a/samod/src/runtime/tokio.rs
+++ b/samod/src/runtime/tokio.rs
@@ -4,7 +4,6 @@ use crate::runtime::{JoinError, RuntimeHandle};
 
 use tokio::task::JoinError as TokioJoinError;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 impl RuntimeHandle for tokio::runtime::Handle {
     type JoinErr = tokio::task::JoinError;
     type JoinFuture<O: Send + 'static> = tokio::task::JoinHandle<O>;

--- a/samod/src/storage.rs
+++ b/samod/src/storage.rs
@@ -9,7 +9,6 @@ mod in_memory;
 pub use in_memory::InMemoryStorage;
 
 #[cfg(feature = "tokio")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub use filesystem::tokio::FilesystemStorage as TokioFilesystemStorage;
 
 #[cfg(feature = "gio")]

--- a/samod/src/websocket.rs
+++ b/samod/src/websocket.rs
@@ -17,7 +17,6 @@ pub enum WsMessage {
 }
 
 #[cfg(feature = "tungstenite")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tungstenite")))]
 impl From<WsMessage> for tungstenite::Message {
     fn from(msg: WsMessage) -> Self {
         match msg {
@@ -31,7 +30,6 @@ impl From<WsMessage> for tungstenite::Message {
 }
 
 #[cfg(feature = "tungstenite")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tungstenite")))]
 impl From<tungstenite::Message> for WsMessage {
     fn from(msg: tungstenite::Message) -> Self {
         match msg {
@@ -46,7 +44,6 @@ impl From<tungstenite::Message> for WsMessage {
 }
 
 #[cfg(feature = "axum")]
-#[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
 impl From<WsMessage> for axum::extract::ws::Message {
     fn from(msg: WsMessage) -> Self {
         match msg {
@@ -60,7 +57,6 @@ impl From<WsMessage> for axum::extract::ws::Message {
 }
 
 #[cfg(feature = "axum")]
-#[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
 impl From<axum::extract::ws::Message> for WsMessage {
     fn from(msg: axum::extract::ws::Message) -> Self {
         match msg {
@@ -76,7 +72,6 @@ impl From<axum::extract::ws::Message> for WsMessage {
 impl Repo {
     /// Connect a tungstenite websocket
     #[cfg(feature = "tungstenite")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tungstenite")))]
     pub fn connect_tungstenite<S>(
         &self,
         socket: S,
@@ -97,7 +92,6 @@ impl Repo {
 
     /// Accept a websocket in an axum handler
     #[cfg(feature = "axum")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
     pub fn accept_axum<S>(&self, stream: S) -> impl Future<Output = ConnFinishedReason> + 'static
     where
         S: Sink<axum::extract::ws::Message, Error = axum::Error>


### PR DESCRIPTION
Problem: we were using `cfg_attr(docrs, doc(cfg(...)))` in many places to generate nice "only available if" messages in the docs. This leads to lots of repetition and is easy to forget to add in new places.

Solution: use the new `doc_auto_cfg` feature of rustdoc[1] which does the same thing automatically.

[1]: https://doc.rust-lang.org/beta/unstable-book/language-features/doc-auto-cfg.html#doc_auto_cfg