### PR TITLE
fix: don't delete the current compacted chunk when compacting

### DIFF
--- a/samod-core/src/actors/document.rs
+++ b/samod-core/src/actors/document.rs
@@ -36,6 +36,7 @@ pub mod errors;
 pub mod io;
 mod load;
 mod on_disk_state;
+pub use on_disk_state::CompactionHash;
 mod peer_doc_connection;
 mod ready;
 mod request;

--- a/samod-core/src/actors/document/on_disk_state/compaction_hash.rs
+++ b/samod-core/src/actors/document/on_disk_state/compaction_hash.rs
@@ -3,7 +3,18 @@ use sha2::Digest;
 
 /// The SHA-256 hash of a set of change hashes, used to uniquely identify a compacted document
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
-pub(crate) struct CompactionHash([u8; 32]);
+pub struct CompactionHash([u8; 32]);
+
+impl CompactionHash {
+    pub fn new(change_hashes: &[ChangeHash]) -> Self {
+        let mut hasher = sha2::Sha256::new();
+        for hash in change_hashes {
+            hasher.update(hash.as_ref());
+        }
+        let hash_result = hasher.finalize();
+        Self(hash_result.into())
+    }
+}
 
 impl std::fmt::Debug for CompactionHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -14,17 +25,5 @@ impl std::fmt::Debug for CompactionHash {
 impl std::fmt::Display for CompactionHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", hex::encode(self.0))
-    }
-}
-
-impl From<Vec<ChangeHash>> for CompactionHash {
-    fn from(mut change_hashes: Vec<ChangeHash>) -> Self {
-        change_hashes.sort();
-        let mut hasher = sha2::Sha256::new();
-        for hash in change_hashes {
-            hasher.update(hash.as_ref());
-        }
-        let hash_result = hasher.finalize();
-        Self(hash_result.into())
     }
 }

--- a/samod-core/src/lib.rs
+++ b/samod-core/src/lib.rs
@@ -9,7 +9,7 @@ pub mod network;
 pub use network::ConnectionId;
 mod peer_id;
 
-pub use actors::document::DocumentActorId;
+pub use actors::document::{CompactionHash, DocumentActorId};
 pub use document_changed::DocumentChanged;
 pub use document_id::{BadDocumentId, DocumentId};
 pub mod io;

--- a/samod-core/src/storage_key.rs
+++ b/samod-core/src/storage_key.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use automerge::ChangeHash;
 
-use crate::DocumentId;
+use crate::{CompactionHash, DocumentId};
 
 /// A hierarchical key for storage operations in the samod-core system.
 ///
@@ -46,11 +46,11 @@ impl StorageKey {
         ])
     }
 
-    pub fn snapshot_path(doc_id: DocumentId, compaction_hash: String) -> StorageKey {
+    pub fn snapshot_path(doc_id: &DocumentId, compaction_hash: &CompactionHash) -> StorageKey {
         StorageKey(vec![
             doc_id.to_string(),
             "snapshot".to_string(),
-            compaction_hash,
+            compaction_hash.to_string(),
         ])
     }
 

--- a/samod-core/tests/compaction.rs
+++ b/samod-core/tests/compaction.rs
@@ -1,4 +1,7 @@
-use automerge::{AutomergeError, ROOT, transaction::Transactable};
+use std::collections::HashMap;
+
+use automerge::{Automerge, AutomergeError, ROOT, transaction::Transactable};
+use samod_core::{CompactionHash, DocumentId, StorageKey};
 use samod_test_harness::{Network, RunningDocIds};
 
 fn init_logging() {
@@ -54,4 +57,60 @@ fn many_changes_are_compacted() {
         .unwrap();
 
     assert_eq!(doc_heads, heads_on_alice2);
+}
+
+#[test]
+fn many_changes_compact_but_do_not_delete_existing_snapshot() {
+    // This tests a scenario where a bunch of changes have been compacted but
+    // the original incremental changes were note deleted for whatever reason.
+    // That is, storage looks something like this:
+    //
+    // /<document ID>/incrementals/<change 1>
+    // ..
+    // /<document ID>/incrementals/<change 100>
+    // /<document ID>/snapshots/<snapshot 1>
+    //
+    // Where <snapshot 1> is a snapshot of the document made out of the 100 changes
+    //
+    // The issue that could happen is that on loading the document the repo decides
+    // to compact the document (because there are a lot of incremental changes) but
+    // the compaction produces the same compacted chunk. This will lead the repo to
+    // actually delete the snapshot as it believes it is superceded by the compacted
+    // chunk it just wrote.
+
+    // first set up storage
+    let mut storage = HashMap::new();
+    let doc_id = DocumentId::new(&mut rand::rng());
+    let mut doc = Automerge::new();
+    for i in 0..100 {
+        doc.transact(|tx| {
+            tx.put(ROOT, "foo", format!("bar {}", i))?;
+            Ok::<_, AutomergeError>(())
+        })
+        .unwrap();
+        let change = doc.get_last_local_change().unwrap();
+        storage.insert(
+            StorageKey::incremental_path(&doc_id, change.hash()),
+            change.raw_bytes().to_vec(),
+        );
+    }
+    // Now write the snapshot
+    let snapshot = doc.save();
+    let snapshot_hash = CompactionHash::new(&doc.get_heads());
+    storage.insert(StorageKey::snapshot_path(&doc_id, &snapshot_hash), snapshot);
+
+    // Now, load an actor with this storage
+    let mut network = Network::new();
+    let alice = network.create_samod_with_storage("alice", storage);
+
+    // Now look up the document, this will trigger a compactoin
+    let _actor_id = network.samod(&alice).find_document(&doc_id).unwrap();
+
+    // Now create another actor with the same storage
+    let alice_storage = network.samod(&alice).storage().clone();
+    let bob = network.create_samod_with_storage("bob", alice_storage);
+    let _actor_id = network
+        .samod(&bob)
+        .find_document(&doc_id)
+        .expect("bob should have the document");
 }


### PR DESCRIPTION
Problem: it is possible for the compaction logic to lose data if the following sequence of events occurs:

1. Enough chunks are created to trigger a compaction. Storage looks like this:
    - /<document ID>/incremental/chunk1  ...
    - /<document ID>/incremental/chunk100 
2. The compaction process writes a new compacted chunk. Storage like this:
    - /<document ID>/incremental/chunk1  ...
    - /<document ID>/incremental/chunk100 
    - /<document ID>/snapshot/compacted_chunk1
3. Before the compaction process can delete the old chunks, the process is killed for some reason
4. The process restarts, and the compaction process runs again, seeing the same number of chunks as before. This triggers compaction. 
5. Once the new compacted chunk is written, the old chunks are deleted, but "old chunks" now includes the compacted chunk because it's the same as the chunk written in step 2.

The problem is that when the compaction process runs, it deletes everything that it read from disk, even if this includes the compacted chunk it is currently writing.

Solution: when deleting old chunks, don't delete the chunk matching the one currently being written.

While we're here I also made the `CompactionHash` struct public, as it's useful for testing and might be useful elsewhere as well.