### PR TITLE
samod-core: don't request from everyone whilst syncing

### DIFF
--- a/samod-core/src/actors/document/doc_state.rs
+++ b/samod-core/src/actors/document/doc_state.rs
@@ -218,7 +218,7 @@ impl DocState {
         }
     }
 
-    pub fn handle_doc_message(
+    pub(crate) fn handle_doc_message(
         &mut self,
         now: UnixTimestamp,
         out: &mut DocActorResult,

--- a/samod-core/src/actors/document/document_actor.rs
+++ b/samod-core/src/actors/document/document_actor.rs
@@ -45,6 +45,7 @@ pub struct DocumentActor {
 
 impl DocumentActor {
     /// Creates a new document actor for the specified document.
+    #[tracing::instrument(skip(initial_content, initial_connections))]
     pub fn new(
         now: UnixTimestamp,
         SpawnArgs {
@@ -73,7 +74,7 @@ impl DocumentActor {
 
         let mut actor = Self {
             document_id,
-            local_peer_id,
+            local_peer_id: local_peer_id.clone(),
             id: actor_id,
             doc_state: state,
             load_state,
@@ -235,6 +236,7 @@ impl DocumentActor {
         self.doc_state.is_ready()
     }
 
+    #[tracing::instrument(skip(self, input, out), fields(local_peer_id=%self.local_peer_id))]
     fn handle_input(&mut self, now: UnixTimestamp, input: ActorInput, out: &mut DocActorResult) {
         match input {
             ActorInput::Terminate => {


### PR DESCRIPTION
The existing logic in `samod-core` when we receive a sync message or request for a document we don't currently have is to immediately send a request to every other peer we are connected to. This causes problems if the incoming message is a sync message.

Say we have three peers connected like this:

alice <-> bob <-> charlie <-> derek

Alice is configured to announce everything to bob. Say Alice creates a document and Derek queries for it before the sync from Alice to Bob to Charlie has completed. The request handling logic will result in the following sequence of events:

* Alice announces document to bob
* Bob begins syncing with Alice
* Bob also sends a request to Charlie for the document
* Derek begins finding the document
* Derek sends a request to Charlie

At this point Charlie has received a request from Bob and a request from Derek, from Charlies perspective no-one has the document so he returns a not-available response to Derek.

To solve this we don't send outgoing request messages whilst we have at least one peer who is syncing with us.