### PR TITLE
samod: Allow non-send tasks

### DIFF
--- a/samod/src/announce_policy.rs
+++ b/samod/src/announce_policy.rs
@@ -30,6 +30,19 @@ pub trait AnnouncePolicy: Clone + Send + 'static {
     ) -> impl Future<Output = bool> + Send + 'static;
 }
 
+/// A version of [`AnnouncePolicy`] that can be used with runtimes that don't
+/// require `Send` or `'static` bounds. See the [module level documentation on
+/// runtimes](./index.html#runtimes) for more details.
+pub trait LocalAnnouncePolicy: Clone + 'static {
+    fn should_announce(&self, doc_id: DocumentId, peer_id: PeerId) -> impl Future<Output = bool>;
+}
+
+impl<A: AnnouncePolicy> LocalAnnouncePolicy for A {
+    fn should_announce(&self, doc_id: DocumentId, peer_id: PeerId) -> impl Future<Output = bool> {
+        AnnouncePolicy::should_announce(self, doc_id, peer_id)
+    }
+}
+
 impl<F> AnnouncePolicy for F
 where
     F: Fn(DocumentId, PeerId) -> bool + Clone + Send + 'static,

--- a/samod/src/io_loop.rs
+++ b/samod/src/io_loop.rs
@@ -8,7 +8,8 @@ use samod_core::{
 };
 
 use crate::{
-    ActorHandle, Inner, actor_task::ActorTask, announce_policy::AnnouncePolicy, storage::Storage,
+    ActorHandle, Inner, actor_task::ActorTask, announce_policy::LocalAnnouncePolicy,
+    storage::LocalStorage,
 };
 
 pub(crate) struct IoLoopTask {
@@ -23,7 +24,7 @@ struct IoLoopResult {
 }
 
 #[tracing::instrument(skip(inner, storage, announce_policy, rx))]
-pub(crate) async fn io_loop<S: Storage, A: AnnouncePolicy>(
+pub(crate) async fn io_loop<S: LocalStorage, A: LocalAnnouncePolicy>(
     local_peer_id: PeerId,
     inner: Arc<Mutex<Inner>>,
     storage: S,
@@ -74,7 +75,7 @@ pub(crate) async fn io_loop<S: Storage, A: AnnouncePolicy>(
     }
 }
 
-async fn dispatch_document_task<S: Storage, A: AnnouncePolicy>(
+async fn dispatch_document_task<S: LocalStorage, A: LocalAnnouncePolicy>(
     storage: S,
     announce: A,
     document_id: DocumentId,
@@ -95,7 +96,7 @@ async fn dispatch_document_task<S: Storage, A: AnnouncePolicy>(
 }
 
 #[tracing::instrument(skip(task, storage))]
-pub(crate) async fn dispatch_storage_task<S: Storage>(
+pub(crate) async fn dispatch_storage_task<S: LocalStorage>(
     task: StorageTask,
     storage: S,
 ) -> StorageResult {

--- a/samod/src/lib.rs
+++ b/samod/src/lib.rs
@@ -30,9 +30,8 @@
 //!
 //! Typically then, your workflow will look like this:
 //!
-//! * Initialize a `Repo` at application startup, passing it a
-//!   [`RuntimeHandle`](crate::runtime::RuntimeHandle) implementation and
-//!   [`Storage`] implementation
+//! * Initialize a `Repo` at application startup, passing it a [`RuntimeHandle`]
+//!   implementation and [`Storage`] implementation
 //! * Whenever you have connections available (maybe you are connecting to a
 //!   sync server, maybe you are receiving peer-to-peer connections) you call
 //!   [`Repo::connect`] to drive the connection state.
@@ -58,17 +57,22 @@
 //! })
 //! ```
 //!
-//! The first argument to `builder` is an implementation of
-//! [`RuntimeHandle`](crate::runtime::RuntimeHandle). Default implementations
-//! are provided for `tokio` and `gio` which can be conveniently used via
-//! [`Repo::build_tokio`] and [`Repo::build_gio`] respectively. The
-//! [`RuntimeHandle`](crate::runtime::RuntimeHandle) trait is straightforward to
-//! implement if you want to use some other async runtime.
+//! The first argument to `builder` is an implementation of [`RuntimeHandle`].
+//! Default implementations are provided for `tokio` and `gio` which can be
+//! conveniently used via [`Repo::build_tokio`] and [`Repo::build_gio`]
+//! respectively. The [`RuntimeHandle`] trait is straightforward to implement if
+//! you want to use some other async runtime.
 //!
 //! By default `samod` uses an in-memory storage implementation. This is great
 //! for prototyping but in most cases you do actually want to persist data somewhere.
 //! In this case you'll need an implementation of [`Storage`] to pass to
 //! [`RepoBuilder::with_storage`]
+//!
+//! It is possible to use [`Storage`] and [`AnnouncePolicy`] implementations which
+//! do not produce `Send` futures. In this case you will also need a runtime which
+//! can spawn non-`Send` futures. See the [runtimes](#runtimes) section for more
+//! details.
+//!
 //!
 //! ### Connecting to peers
 //!
@@ -161,6 +165,27 @@
 //! }).load().await;
 //! # });
 //! ```
+//!
+//! ## Runtimes
+//!
+//! [`RuntimeHandle`] is a trait which is intended to abstract over the various
+//! runtimes available in the rust ecosystem. The most common runtime is `tokio`.
+//! `tokio` is a work-stealing runtime which means that the futures spawned on it
+//! must be [`Send`], so that they can be moved between threads. This means that
+//! [`RuntimeHandle::spawn`] requires [`Send`] futures. This in turn means that
+//! the futures returned by the [`Storage`] and [`AnnouncePolicy`] traits are
+//! also [`Send`] so that they can be spawned onto the [`RuntimeHandle`].
+//!
+//! In many cases though, you may have a runtime which doesn't require [`Send`]
+//! futures and you may have storage and announce policy implementations which
+//! cannot produce [`Send`] futures. This would often be the case in single
+//! threaded runtimes for example. In these cases you can instead implement
+//! [`LocalRuntimeHandle`], which doesn't require [`Send`] futures and then
+//! you implement [`LocalStorage`] and [`LocalAnnouncePolicy`] traits for
+//! your storage and announce policy implementations. You configure all these
+//! things via the [`RepoBuilder`] struct. Once you've configured the storage
+//! and announce policy implementations to use local variants you can then
+//! create a local [`Repo`] using [`RepoBuilder::load_local`].
 //!
 //! ## Why not just Automerge?
 //!
@@ -260,6 +285,7 @@ use futures::{
     stream::FuturesUnordered,
 };
 use rand::SeedableRng;
+use rayon::ThreadPool;
 pub use samod_core::{AutomergeUrl, DocumentId, PeerId, network::ConnDirection};
 use samod_core::{
     CommandId, CommandResult, ConnectionId, DocumentActorId, LoaderState, UnixTimestamp,
@@ -293,12 +319,16 @@ pub use peer_connection_info::ConnectionInfo;
 mod stopped;
 pub use stopped::Stopped;
 pub mod storage;
-pub use crate::announce_policy::{AlwaysAnnounce, AnnouncePolicy};
-use crate::storage::InMemoryStorage;
+pub use crate::announce_policy::{AlwaysAnnounce, AnnouncePolicy, LocalAnnouncePolicy};
 use crate::{
     doc_actor_inner::DocActorInner,
     doc_runner::{DocRunner, SpawnedActor},
     storage::Storage,
+};
+use crate::{
+    io_loop::IoLoopTask,
+    runtime::{LocalRuntimeHandle, RuntimeHandle},
+    storage::{InMemoryStorage, LocalStorage},
 };
 pub mod runtime;
 pub mod websocket;
@@ -381,79 +411,30 @@ impl Repo {
             announce_policy,
             threadpool,
         } = builder;
-        let mut rng = rand::rngs::StdRng::from_rng(&mut rand::rng());
-        let peer_id = peer_id.unwrap_or_else(|| PeerId::new_with_rng(&mut rng));
-        let mut loading = Hub::load(peer_id.clone());
-        let mut running_tasks = FuturesUnordered::new();
-        let hub = loop {
-            match loading.step(&mut rng, UnixTimestamp::now()) {
-                LoaderState::NeedIo(items) => {
-                    for IoTask {
-                        task_id,
-                        action: task,
-                    } in items
-                    {
-                        let storage = storage.clone();
-                        running_tasks.push(async move {
-                            let result = io_loop::dispatch_storage_task(task, storage).await;
-                            (task_id, result)
-                        })
-                    }
-                }
-                LoaderState::Loaded(hub) => break hub,
-            }
-            let (task_id, next_result) = running_tasks.select_next_some().await;
-            loading.provide_io_result(IoResult {
-                task_id,
-                payload: next_result,
-            });
-        };
+        let task_setup = TaskSetup::new(storage.clone(), peer_id, threadpool).await;
+        let inner = task_setup.inner.clone();
+        task_setup.spawn_tasks(runtime, storage, announce_policy);
+        Self { inner }
+    }
 
-        let (tx_storage, rx_storage) = async_channel::unbounded();
-        let (tx_to_core, rx_from_core) = async_channel::unbounded();
-        let doc_runner = if let Some(threadpool) = threadpool {
-            DocRunner::Threadpool(threadpool)
-        } else {
-            let (tx, rx) = async_channel::unbounded();
-            runtime.spawn(async_actor_runner(rx).boxed());
-            DocRunner::Async { tx }
-        };
-        let inner = Arc::new(Mutex::new(Inner {
-            doc_runner,
-            actors: HashMap::new(),
-            hub: *hub,
-            pending_commands: HashMap::new(),
-            connections: HashMap::new(),
-            tx_io: tx_storage,
-            tx_to_core,
-            waiting_for_connection: HashMap::new(),
-            stop_waiters: Vec::new(),
-            rng: rand::rngs::StdRng::from_os_rng(),
-        }));
-
-        runtime.spawn(
-            io_loop::io_loop(
-                peer_id.clone(),
-                inner.clone(),
-                storage,
-                announce_policy,
-                rx_storage,
-            )
-            .boxed(),
-        );
-        runtime.spawn({
-            let inner = inner.clone();
-            async move {
-                let rx = rx_from_core;
-                while let Ok((actor_id, msg)) = rx.recv().await {
-                    let event = HubEvent::actor_message(actor_id, msg);
-                    inner.lock().unwrap().handle_event(event);
-                }
-            }
-            .instrument(tracing::info_span!("actor_loop", local_peer_id=%peer_id))
-            .boxed()
-        });
-
+    pub(crate) async fn load_local<
+        'a,
+        R: runtime::LocalRuntimeHandle + 'a,
+        S: LocalStorage + 'a,
+        A: LocalAnnouncePolicy + 'a,
+    >(
+        builder: RepoBuilder<S, R, A>,
+    ) -> Self {
+        let RepoBuilder {
+            storage,
+            runtime,
+            peer_id,
+            announce_policy,
+            threadpool,
+        } = builder;
+        let task_setup = TaskSetup::new(storage.clone(), peer_id, threadpool).await;
+        let inner = task_setup.inner.clone();
+        task_setup.spawn_tasks_local(runtime, storage, announce_policy);
         Self { inner }
     }
 
@@ -955,6 +936,165 @@ async fn async_actor_runner(rx: async_channel::Receiver<SpawnedActor>) {
     // Wait for all actors to stop
     while running_actors.next().await.is_some() {
         // nothing to do
+    }
+}
+
+/// All the information needed to spawn the background tasks
+///
+/// When we construct a `Repo` we need to spawn a number of tasks onto the
+/// runtime to do things like handle storage tasks. We have to split the
+/// spawn process into two stages:
+///
+/// * Create the channels which are used to communicate with the background tasks
+/// * Spawn the background tasks onto the runtime
+///
+/// The reason we have to split into these two stages is so that we can work with
+/// runtimes that don't support non-`Send` tasks. This split is represented by the
+/// `TaskSetup::spawn_tasks` and `TaskSetup::spawn_tasks_local` methods.
+struct TaskSetup {
+    peer_id: PeerId,
+    inner: Arc<Mutex<Inner>>,
+    rx_storage: async_channel::Receiver<IoLoopTask>,
+    rx_from_core: async_channel::Receiver<(DocumentActorId, DocToHubMsg)>,
+    rx_actor: Option<async_channel::Receiver<SpawnedActor>>,
+}
+
+impl TaskSetup {
+    async fn new<S: LocalStorage>(
+        storage: S,
+        peer_id: Option<PeerId>,
+        threadpool: Option<ThreadPool>,
+    ) -> TaskSetup {
+        let mut rng = rand::rngs::StdRng::from_rng(&mut rand::rng());
+        let peer_id = peer_id.unwrap_or_else(|| PeerId::new_with_rng(&mut rng));
+        let hub = load_hub(storage.clone(), Hub::load(peer_id.clone())).await;
+
+        let (tx_storage, rx_storage) = async_channel::unbounded();
+        let (tx_to_core, rx_from_core) = async_channel::unbounded();
+        let mut rx_actor = None;
+        let doc_runner = if let Some(threadpool) = threadpool {
+            DocRunner::Threadpool(threadpool)
+        } else {
+            let (tx, rx) = async_channel::unbounded();
+            rx_actor = Some(rx);
+            // tasks.push(async_actor_runner(rx).boxed_local());
+            DocRunner::Async { tx }
+        };
+        let inner = Arc::new(Mutex::new(Inner {
+            doc_runner,
+            actors: HashMap::new(),
+            hub: *hub,
+            pending_commands: HashMap::new(),
+            connections: HashMap::new(),
+            tx_io: tx_storage,
+            tx_to_core,
+            waiting_for_connection: HashMap::new(),
+            stop_waiters: Vec::new(),
+            rng: rand::rngs::StdRng::from_os_rng(),
+        }));
+
+        TaskSetup {
+            peer_id,
+            inner,
+            rx_actor,
+            rx_from_core,
+            rx_storage,
+        }
+    }
+    fn spawn_tasks_local<R: LocalRuntimeHandle, S: LocalStorage, A: LocalAnnouncePolicy>(
+        self,
+        runtime: R,
+        storage: S,
+        announce_policy: A,
+    ) {
+        runtime.spawn(
+            io_loop::io_loop(
+                self.peer_id.clone(),
+                self.inner.clone(),
+                storage,
+                announce_policy,
+                self.rx_storage,
+            )
+            .boxed_local(),
+        );
+        runtime.spawn({
+            let peer_id = self.peer_id.clone();
+            let inner = self.inner.clone();
+            async move {
+                let rx = self.rx_from_core;
+                while let Ok((actor_id, msg)) = rx.recv().await {
+                    let event = HubEvent::actor_message(actor_id, msg);
+                    inner.lock().unwrap().handle_event(event);
+                }
+            }
+            .instrument(tracing::info_span!("actor_loop", local_peer_id=%peer_id))
+            .boxed_local()
+        });
+        if let Some(rx_actor) = self.rx_actor {
+            runtime.spawn(async_actor_runner(rx_actor).boxed_local());
+        }
+    }
+
+    fn spawn_tasks<R: RuntimeHandle, S: Storage, A: AnnouncePolicy>(
+        self,
+        runtime: R,
+        storage: S,
+        announce_policy: A,
+    ) {
+        runtime.spawn(
+            io_loop::io_loop(
+                self.peer_id.clone(),
+                self.inner.clone(),
+                storage,
+                announce_policy,
+                self.rx_storage,
+            )
+            .boxed(),
+        );
+        runtime.spawn({
+            let peer_id = self.peer_id.clone();
+            let inner = self.inner.clone();
+            async move {
+                let rx = self.rx_from_core;
+                while let Ok((actor_id, msg)) = rx.recv().await {
+                    let event = HubEvent::actor_message(actor_id, msg);
+                    inner.lock().unwrap().handle_event(event);
+                }
+            }
+            .instrument(tracing::info_span!("actor_loop", local_peer_id=%peer_id))
+            .boxed()
+        });
+        if let Some(rx_actor) = self.rx_actor {
+            runtime.spawn(async_actor_runner(rx_actor).boxed());
+        }
+    }
+}
+
+async fn load_hub<S: LocalStorage>(storage: S, mut loading: samod_core::SamodLoader) -> Box<Hub> {
+    let mut rng = rand::rngs::StdRng::from_os_rng();
+    let mut running_tasks = FuturesUnordered::new();
+    loop {
+        match loading.step(&mut rng, UnixTimestamp::now()) {
+            LoaderState::NeedIo(items) => {
+                for IoTask {
+                    task_id,
+                    action: task,
+                } in items
+                {
+                    let storage = storage.clone();
+                    running_tasks.push(async move {
+                        let result = io_loop::dispatch_storage_task(task, storage).await;
+                        (task_id, result)
+                    })
+                }
+            }
+            LoaderState::Loaded(hub) => break hub,
+        }
+        let (task_id, next_result) = running_tasks.select_next_some().await;
+        loading.provide_io_result(IoResult {
+            task_id,
+            payload: next_result,
+        });
     }
 }
 

--- a/samod/src/runtime.rs
+++ b/samod/src/runtime.rs
@@ -19,3 +19,20 @@ pub trait RuntimeHandle: 'static {
     /// Spawn a task to be run in the background
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send + 'static>>);
 }
+
+/// An abstraction over the asynchronous runtime the repo is running on
+///
+/// When a [`Repo`](crate::Repo) starts up it spawns a number of tasks which run
+/// until the repo is shutdown. These tasks do things like handle IO using
+/// [`Storage`](crate::Storage) or pass messages between different document
+/// threads and the central control loop of the repo. [`LocalRuntimeHandle`]
+/// represents this ability to spawn tasks.
+///
+/// The difference between this trait and the [`RuntimeHandle`] trait is that
+/// the `LocalRuntimeHandle` does not have a `Send` or 'static bound, enabling
+/// it to be used with runtimes that don't require this. See the [module level
+/// documentation on runtimes](../index.html#runtimes) for more details.
+pub trait LocalRuntimeHandle {
+    /// Spawn a task to be run in the background
+    fn spawn(&self, f: Pin<Box<dyn Future<Output = ()>>>);
+}

--- a/samod/src/runtime/localpool.rs
+++ b/samod/src/runtime/localpool.rs
@@ -2,13 +2,19 @@ use std::pin::Pin;
 
 use futures::{executor::LocalSpawner, task::LocalSpawnExt};
 
-use crate::runtime::RuntimeHandle;
+use crate::runtime::{LocalRuntimeHandle, RuntimeHandle};
 
 #[derive(Clone)]
 pub struct LocalPoolRuntime;
 
 impl RuntimeHandle for LocalSpawner {
     fn spawn(&self, f: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+        self.spawn_local(f).unwrap();
+    }
+}
+
+impl LocalRuntimeHandle for LocalSpawner {
+    fn spawn(&self, f: Pin<Box<dyn Future<Output = ()>>>) {
         self.spawn_local(f).unwrap();
     }
 }

--- a/samod/src/storage.rs
+++ b/samod/src/storage.rs
@@ -48,3 +48,38 @@ pub trait Storage: Send + Clone + 'static {
     /// Delete a value from storage
     fn delete(&self, key: StorageKey) -> impl Future<Output = ()> + Send;
 }
+
+/// A version of [`Storage`] that can be used with runtimes that don't require
+/// `Send` or `'static` bounds. See the [module level documentation on
+/// runtimes](../index.html#runtimes) for more details.
+pub trait LocalStorage: Clone + 'static {
+    /// Load a specific key from storage
+    fn load(&self, key: StorageKey) -> impl Future<Output = Option<Vec<u8>>>;
+    /// Load a range of keys from storage, all of which begin with `prefix`
+    ///
+    /// Note that you can use [`StorageKey::is_prefix_of`] to implement this
+    /// in simple cases
+    fn load_range(&self, prefix: StorageKey) -> impl Future<Output = HashMap<StorageKey, Vec<u8>>>;
+    /// Put a particular value into storage
+    fn put(&self, key: StorageKey, data: Vec<u8>) -> impl Future<Output = ()>;
+    /// Delete a value from storage
+    fn delete(&self, key: StorageKey) -> impl Future<Output = ()>;
+}
+
+impl<S: Storage> LocalStorage for S {
+    fn load(&self, key: StorageKey) -> impl Future<Output = Option<Vec<u8>>> {
+        Storage::load(self, key)
+    }
+
+    fn load_range(&self, prefix: StorageKey) -> impl Future<Output = HashMap<StorageKey, Vec<u8>>> {
+        Storage::load_range(self, prefix)
+    }
+
+    fn put(&self, key: StorageKey, data: Vec<u8>) -> impl Future<Output = ()> {
+        Storage::put(self, key, data)
+    }
+
+    fn delete(&self, key: StorageKey) -> impl Future<Output = ()> {
+        Storage::delete(self, key)
+    }
+}

--- a/samod/tests/localpool_smoke.rs
+++ b/samod/tests/localpool_smoke.rs
@@ -31,7 +31,7 @@ fn test_localpool() {
                 let alice = samod::Repo::build_localpool(spawner.clone())
                     .with_peer_id("alice".into())
                     .with_threadpool(None)
-                    .load()
+                    .load_local()
                     .await;
 
                 let bob = samod::Repo::build_localpool(spawner.clone())


### PR DESCRIPTION
Problem: in some cases it's not possible to produce a `Storage` or `AnnouncePolicy` implementation that produces `Send` futures, which means those futures can't be spawned onto runtimes like `tokio` which require `Send` futures to transfer tasks between threads. This constraint is reflected in the `RuntimeHandle::spawn` method, which requires the spawned future to be `Send`.

Solution: add "local" variants of `RuntimeHandle`, `Storage`, and `AnnouncePolicy`. These don't require `Send` futures and so can be used with runtimes (such as single threaded ones like
`futures::executor::LocalPool`) that don't require `Send` futures. These new variants can be used via the `RepoBuilder::build_local` method.