### PR TITLE
samod: make threadpool usage compile time optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Build
         run: cargo build --verbose --features tokio
       - name: clippy
-        run: cargo clippy --all-targets --features tokio -- -D warnings
+        run: cargo clippy --all-targets --features samod/tokio,samod/threadpool,samod/axum,samod/tungstenite -- -D warnings
       - name: Run tests
-        run: cargo test --features tokio --verbose
+        run: cargo test --features samod/tokio,samod/threadpool,samod/axum,samod/tungstenite --verbose
+      - name: Run tests without features
+        run: cargo test --verbose --tests

--- a/samod/Cargo.toml
+++ b/samod/Cargo.toml
@@ -12,6 +12,7 @@ tokio = ["dep:tokio", "dep:tokio-util"]
 axum = ["dep:axum", "dep:tokio", "dep:tokio-util"]
 tungstenite = ["dep:tungstenite", "dep:tokio-tungstenite", "tokio"]
 gio = ["dep:gio", "dep:glib"]
+threadpool = ["dep:rayon"]
 
 [dependencies]
 automerge = "0.6.1"
@@ -20,7 +21,7 @@ bytes = "1.10.1"
 chrono = "0.4.41"
 futures = "0.3.31"
 rand = "0.9.1"
-rayon = "1.10.0"
+rayon = { version = "1.10.0", optional = true }
 samod-core = { path = "../samod-core", version = "0.3.1" }
 tokio = { version = "1.46.0", features = ["rt", "time", "fs"], optional = true }
 tokio-tungstenite = { version = "0.27.0", optional = true }

--- a/samod/src/actor_handle.rs
+++ b/samod/src/actor_handle.rs
@@ -1,10 +1,10 @@
 use std::sync::{Arc, Mutex};
 
-use crate::{ActorTask, DocActorInner, DocHandle};
+use crate::{ActorTask, DocActorInner, DocHandle, unbounded::UnboundedSender};
 
 pub(crate) struct ActorHandle {
     #[allow(dead_code)]
     pub(crate) inner: Arc<Mutex<DocActorInner>>,
-    pub(crate) tx: async_channel::Sender<ActorTask>,
+    pub(crate) tx: UnboundedSender<ActorTask>,
     pub(crate) doc: DocHandle,
 }

--- a/samod/src/doc_runner.rs
+++ b/samod/src/doc_runner.rs
@@ -2,22 +2,25 @@ use std::sync::{Arc, Mutex};
 
 use samod_core::{DocumentActorId, DocumentId, actors::document::DocActorResult};
 
-use crate::{actor_task::ActorTask, doc_actor_inner::DocActorInner};
+use crate::{
+    actor_task::ActorTask,
+    doc_actor_inner::DocActorInner,
+    unbounded::{UnboundedReceiver, UnboundedSender},
+};
 
 /// Enum representing the two possible ways of running document actors
 pub(crate) enum DocRunner {
     /// Run the actors on a threadpool
+    #[cfg(feature = "threadpool")]
     Threadpool(rayon::ThreadPool),
     /// Run the actors on an async task which is listening on the other end of `tx`
-    Async {
-        tx: async_channel::Sender<SpawnedActor>,
-    },
+    Async { tx: UnboundedSender<SpawnedActor> },
 }
 
 pub(crate) struct SpawnedActor {
     pub(crate) doc_id: DocumentId,
     pub(crate) actor_id: DocumentActorId,
     pub(crate) inner: Arc<Mutex<DocActorInner>>,
-    pub(crate) rx_tasks: async_channel::Receiver<ActorTask>,
+    pub(crate) rx_tasks: UnboundedReceiver<ActorTask>,
     pub(crate) init_results: DocActorResult,
 }

--- a/samod/src/io_loop.rs
+++ b/samod/src/io_loop.rs
@@ -9,7 +9,7 @@ use samod_core::{
 
 use crate::{
     ActorHandle, Inner, actor_task::ActorTask, announce_policy::LocalAnnouncePolicy,
-    storage::LocalStorage,
+    storage::LocalStorage, unbounded::UnboundedReceiver,
 };
 
 pub(crate) struct IoLoopTask {
@@ -29,7 +29,7 @@ pub(crate) async fn io_loop<S: LocalStorage, A: LocalAnnouncePolicy>(
     inner: Arc<Mutex<Inner>>,
     storage: S,
     announce_policy: A,
-    rx: async_channel::Receiver<IoLoopTask>,
+    rx: UnboundedReceiver<IoLoopTask>,
 ) {
     let mut running_tasks = FuturesUnordered::new();
 
@@ -60,7 +60,7 @@ pub(crate) async fn io_loop<S: LocalStorage, A: LocalAnnouncePolicy>(
                     tracing::warn!(?actor_id, "received io result for unknown actor");
                     continue;
                 };
-                let _ = tx.send_blocking(ActorTask::IoComplete(result));
+                let _ = tx.unbounded_send(ActorTask::IoComplete(result));
             }
         }
     }
@@ -71,7 +71,7 @@ pub(crate) async fn io_loop<S: LocalStorage, A: LocalAnnouncePolicy>(
             tracing::warn!(?actor_id, "received io result for unknown actor");
             continue;
         };
-        let _ = tx.send_blocking(ActorTask::IoComplete(result));
+        let _ = tx.unbounded_send(ActorTask::IoComplete(result));
     }
 }
 

--- a/samod/src/unbounded.rs
+++ b/samod/src/unbounded.rs
@@ -1,0 +1,37 @@
+/// A wrapper around `async_channel::unbounded` which removes the `TrySendError::Full` error.
+pub(crate) fn channel<T>() -> (UnboundedSender<T>, UnboundedReceiver<T>) {
+    let (tx, rx) = async_channel::unbounded();
+    (UnboundedSender(tx), UnboundedReceiver(rx))
+}
+
+pub(crate) struct UnboundedSender<T>(async_channel::Sender<T>);
+
+impl<T> UnboundedSender<T> {
+    pub(crate) fn unbounded_send(&self, msg: T) -> Result<(), T> {
+        self.0.try_send(msg).map_err(|e| match e {
+            async_channel::TrySendError::Full(_val) => {
+                unreachable!("this is an unbounded channel")
+            }
+            async_channel::TrySendError::Closed(val) => val,
+        })
+    }
+}
+
+impl<T> Clone for UnboundedSender<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+pub(crate) struct UnboundedReceiver<T>(async_channel::Receiver<T>);
+
+impl<T> UnboundedReceiver<T> {
+    #[cfg(feature = "threadpool")]
+    pub(crate) fn recv_blocking(&self) -> Result<T, async_channel::RecvError> {
+        self.0.recv_blocking()
+    }
+
+    pub(crate) async fn recv(&self) -> Result<T, async_channel::RecvError> {
+        self.0.recv().await
+    }
+}

--- a/samod/tests/localpool_smoke.rs
+++ b/samod/tests/localpool_smoke.rs
@@ -8,7 +8,7 @@ use futures::{
     executor::LocalPool,
     task::{LocalSpawnExt, SpawnExt},
 };
-use samod::ConnDirection;
+use samod::{ConcurrencyConfig, ConnDirection};
 
 fn init_logging() {
     let _ = tracing_subscriber::fmt()
@@ -30,13 +30,12 @@ fn test_localpool() {
             .spawn_local(async move {
                 let alice = samod::Repo::build_localpool(spawner.clone())
                     .with_peer_id("alice".into())
-                    .with_threadpool(None)
                     .load_local()
                     .await;
 
                 let bob = samod::Repo::build_localpool(spawner.clone())
                     .with_peer_id("bob".into())
-                    .with_threadpool(None)
+                    .with_concurrency(ConcurrencyConfig::AsyncRuntime)
                     .load()
                     .await;
 


### PR DESCRIPTION
Problem: the use of the rayon threadpool option to run document actors in paralell requires the use of the
`async_channel::Sender::blocking_send` and
`async_channel::Receiver::recv_blocking` methods, which are behind a conditional compilation flag which is not enabled for `wasm` targets. This means that `samod` cannot be used on `wasm` targets even if the threadpool feature is not being used.

Solution: make the threadpool feature compile time optional behind the `threadpool` feature flag. We also put the `blocking_send` and `recv_blocking` methods behind the same flag so that if the `threadpool` feature is not available `samod` can compile on `wasm` just fine. While we're here add a newtype wrapper for unbounded channels to make it clearer that we expect these channels to be unbounded.