### PR TITLE
samod: Fix JS interop test flake

### DIFF
--- a/samod/interop-test-server/client.js
+++ b/samod/interop-test-server/client.js
@@ -100,20 +100,21 @@ const receiveEphemeral = command({
             description: "The document url to fetch",
         }),
     },
-    handler: ({ port, docUrl }) => {
+    handler: async ({ port, docUrl }) => {
         const repo = new Repo({
             network: [new BrowserWebSocketClientAdapter(`ws://localhost:${port}`)],
         });
         if (!isValidAutomergeUrl(docUrl)) {
             throw new Error("Invalid docUrl");
         }
-        const doc = repo.find(docUrl);
         repo.find(docUrl).then((doc) => {
             doc.on("ephemeral-message", ({ message }) => {
                 if (typeof message === "object" && "message" in message) {
                     console.log(message.message);
                 }
             });
+            // Signal that we're ready to receive ephemeral messages
+            console.log("ready");
         });
     },
 });

--- a/samod/interop-test-server/client.ts
+++ b/samod/interop-test-server/client.ts
@@ -107,20 +107,21 @@ const receiveEphemeral = command({
       description: "The document url to fetch",
     }),
   },
-  handler: ({ port, docUrl }) => {
+  handler: async ({ port, docUrl }) => {
     const repo = new Repo({
       network: [new BrowserWebSocketClientAdapter(`ws://localhost:${port}`)],
     });
     if (!isValidAutomergeUrl(docUrl)) {
       throw new Error("Invalid docUrl");
     }
-    const doc = repo.find(docUrl);
     repo.find(docUrl).then((doc) => {
       doc.on("ephemeral-message", ({ message }) => {
         if (typeof message === "object" && "message" in message) {
           console.log(message.message);
         }
       });
+      // Signal that we're ready to receive ephemeral messages
+      console.log("ready");
     });
   },
 });


### PR DESCRIPTION
Problem: the JS interop test for receiving ephemeral messages in a JS client from a Rust server is flaky, failing intermittently - especially in CI. The way this test works is that it runs two JS client processes which connect to a rust server and then one JS client process sends a message whilst the other listens for ephemeral messages and prints them to stdout. The test harness captures the stdout of the listening client and makes assertions about the messages it received. The problem is that the listening client may not be fully connected and ready to receive messages by the time the sending client sends its message, leading to the listening client missing the message and the test failing.

Solution: modify the JS client code to emit a "ready" message to stdout once it has fully connected to the server and is ready to receive messages. The test harness can then wait for this "ready" message before proceeding to have the sending client send its message.