### PR TITLE
Increase frame size from 8mb to 8gb

### DIFF
--- a/samod/src/lib.rs
+++ b/samod/src/lib.rs
@@ -599,8 +599,12 @@ impl Repo {
         io: Io,
         direction: ConnDirection,
     ) -> Result<Connection, Stopped> {
+        let codec = tokio_util::codec::LengthDelimitedCodec::builder()
+            // 8gb instead of 8mb lol
+            .max_frame_length(8 * 1024 * 1024 * 1024)
+            .new_codec();
         let framed =
-            tokio_util::codec::Framed::new(io, tokio_util::codec::LengthDelimitedCodec::new());
+            tokio_util::codec::Framed::new(io, codec);
         let (write_half, read_half) = framed.split();
         let write_half = write_half
             .with::<Vec<u8>, _, _, std::io::Error>(|msg| std::future::ready(Ok(msg.into())));


### PR DESCRIPTION
Problem: The Tokio default frame size is 8mb, which is pretty small. Larger documents fail to propery send through the pipe.

Solution: Increase the default frame size to 8gb. This is a hack solution and eventually we should implement a syncing solution where documents can be any size.