### PR TITLE
wait for dialers when finding documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,9 @@ conn.handshake_complete().await.unwrap();
 
 // After
 let handle = repo.dial(BackoffConfig::default(), Arc::new(my_dialer)).unwrap();
-let peer_info = handle.established().await.unwrap();
+
 // or, for WebSocket URLs directly:
 let handle = repo.dial_websocket(url, BackoffConfig::default()).unwrap();
-handle.established().await.unwrap();
 ```
 
 #### Incoming connections (previously `Repo::connect(..., ConnDirection::Incoming)`)

--- a/samod-core/src/actors/document/actor_input.rs
+++ b/samod-core/src/actors/document/actor_input.rs
@@ -1,7 +1,10 @@
+use std::collections::HashMap;
+
 use crate::{
+    DialerId,
     actors::{
         document::io::DocumentIoResult,
-        messages::{DocMessage, HubToDocMsgPayload},
+        messages::{DocDialerState, DocMessage, HubToDocMsgPayload},
     },
     io::IoResult,
 };
@@ -28,6 +31,10 @@ pub(crate) enum ActorInput {
     IoComplete(IoResult<DocumentIoResult>),
     Request,
     Tick,
+    /// The set of dialer states has changed.
+    DialerStatesChanged {
+        dialers: HashMap<DialerId, DocDialerState>,
+    },
 }
 
 /// Convert external messages to internal input messages
@@ -53,6 +60,9 @@ impl From<HubToDocMsgPayload> for ActorInput {
                 ActorInput::ConnectionClosed { connection_id }
             }
             HubToDocMsgPayload::RequestAgain => ActorInput::Request,
+            HubToDocMsgPayload::DialerStatesChanged { dialers } => {
+                ActorInput::DialerStatesChanged { dialers }
+            }
         }
     }
 }

--- a/samod-core/src/actors/document/spawn_args.rs
+++ b/samod-core/src/actors/document/spawn_args.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use crate::{ConnectionId, DocumentActorId, PeerId, actors::messages::DocMessage};
+use crate::{
+    ConnectionId, DialerId, DocumentActorId, PeerId,
+    actors::messages::{DocDialerState, DocMessage},
+};
 
 #[derive(Clone)]
 pub struct SpawnArgs {
@@ -9,6 +12,9 @@ pub struct SpawnArgs {
     pub(crate) document_id: crate::DocumentId,
     pub(crate) initial_content: Option<automerge::Automerge>,
     pub(crate) initial_connections: HashMap<ConnectionId, (PeerId, Option<DocMessage>)>,
+    /// Current dialer states at spawn time, so the document actor can factor
+    /// connecting dialers into its availability decisions from the start.
+    pub(crate) dialer_states: HashMap<DialerId, DocDialerState>,
 }
 
 impl std::fmt::Debug for SpawnArgs {

--- a/samod-core/src/actors/messages.rs
+++ b/samod-core/src/actors/messages.rs
@@ -4,7 +4,7 @@ mod sync_message;
 pub(crate) use sync_message::SyncMessage;
 mod hub_to_doc_msg;
 pub use hub_to_doc_msg::HubToDocMsg;
-pub(crate) use hub_to_doc_msg::HubToDocMsgPayload;
+pub(crate) use hub_to_doc_msg::{DocDialerState, HubToDocMsgPayload};
 mod doc_to_hub_msg;
 pub use doc_to_hub_msg::DocToHubMsg;
 pub(crate) use doc_to_hub_msg::{Broadcast, DocToHubMsgPayload};

--- a/samod-core/src/actors/messages/hub_to_doc_msg.rs
+++ b/samod-core/src/actors/messages/hub_to_doc_msg.rs
@@ -1,6 +1,33 @@
-use crate::ConnectionId;
+use std::collections::HashMap;
+
+use crate::{ConnectionId, DialerId};
 
 use super::DocMessage;
+
+/// Dialer state as visible to document actors.
+///
+/// This is a simplified projection of the hub-internal `DialerStatus` that
+/// strips out hub internals (connection IDs, retry timestamps) and only
+/// exposes what document actors need to make availability decisions.
+///
+/// One significant difference to the `DialerStatus` is that we only report
+/// `Connected` if the connection is fully established (i.e. the connection
+/// exists and has a remote peer ID). This is because document actors only care
+/// about whether the connection is actually usable, and reporting `Connected`
+/// too early (e.g. while still in the handshake phase) could mean we mark a
+/// document as unavailable when we are just waiting for a handshake to
+/// complete
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DocDialerState {
+    /// Transport is being established (NeedTransport or TransportPending).
+    Connecting,
+    /// An active connection exists.
+    Connected,
+    /// Waiting for backoff before retrying.
+    WaitingToRetry,
+    /// Permanently failed (max retries exceeded).
+    Failed,
+}
 
 /// Messages sent from the hub to document actors.
 #[derive(Debug, Clone)]
@@ -26,5 +53,13 @@ pub(crate) enum HubToDocMsgPayload {
     HandleDocMessage {
         connection_id: ConnectionId,
         message: DocMessage,
+    },
+
+    /// Notify the actor of the current dialer states.
+    ///
+    /// Sent whenever the set of dialer states changes. The full map is sent
+    /// each time (not deltas) for robustness.
+    DialerStatesChanged {
+        dialers: HashMap<DialerId, DocDialerState>,
     },
 }

--- a/samod-core/tests/wait_for_dialer.rs
+++ b/samod-core/tests/wait_for_dialer.rs
@@ -1,0 +1,377 @@
+//! Tests for waiting on connecting dialers before marking documents as NotFound.
+//!
+//! When a document actor has no connected peers but there is a dialer actively
+//! connecting (in NeedTransport or TransportPending state), the document should
+//! not be marked NotFound — it should wait for the dialer to either connect
+//! (at which point sync can proceed) or fail permanently (at which point we
+//! give up).
+
+use std::time::Duration;
+
+use automerge::{ROOT, ReadDoc, transaction::Transactable};
+use samod_core::{BackoffConfig, DialerConfig, DocumentId};
+use samod_test_harness::{Network, RunningDocIds};
+
+fn init_logging() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+}
+
+/// A dialer config with a long backoff so it stays in TransportPending and
+/// doesn't auto-retry during the test.
+fn non_retrying_dialer(url: &str) -> DialerConfig {
+    DialerConfig {
+        url: url::Url::parse(url).unwrap(),
+        backoff: BackoffConfig {
+            initial_delay: Duration::from_secs(999),
+            max_delay: Duration::from_secs(999),
+            max_retries: Some(0),
+        },
+    }
+}
+
+/// Helper macro: create a document on a peer, write some data, return the doc ID.
+/// (Macro because SamodId is not publicly exported from the test harness.)
+macro_rules! create_doc_with_data {
+    ($network:expr, $peer:expr) => {{
+        let RunningDocIds { doc_id, actor_id } = $network.samod(&$peer).create_document();
+        $network
+            .samod(&$peer)
+            .with_document_by_actor(actor_id, |doc| {
+                let mut tx = doc.transaction();
+                tx.put(ROOT, "key", "value").unwrap();
+                tx.commit();
+            })
+            .unwrap();
+        doc_id
+    }};
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+/// When there are no dialers and no connections, find should resolve to
+/// NotFound immediately (baseline behavior, unchanged).
+#[test]
+fn find_without_dialers_resolves_to_not_found() {
+    init_logging();
+
+    let mut network = Network::new();
+    let bob = network.create_samod("Bob");
+
+    let fake_doc_id = DocumentId::new(&mut rand::rng());
+    let result = network.samod(&bob).find_document(&fake_doc_id);
+
+    assert!(result.is_none(), "document should not be found");
+}
+
+/// When a dialer is in TransportPending state, find should NOT resolve to
+/// NotFound — it should stay pending, waiting for the dialer to connect.
+#[test]
+fn find_with_connecting_dialer_stays_pending() {
+    init_logging();
+
+    let mut network = Network::new();
+    let bob = network.create_samod("Bob");
+
+    // Add a dialer — it enters TransportPending immediately
+    let _dialer_id = network
+        .samod(&bob)
+        .add_dialer(non_retrying_dialer("wss://sync.example.com"));
+
+    // Start a find for a document that doesn't exist locally
+    let fake_doc_id = DocumentId::new(&mut rand::rng());
+    let find_cmd = network.samod(&bob).begin_find_document(&fake_doc_id);
+
+    // Process events
+    network.run_until_quiescent();
+
+    // The find should NOT have completed — the dialer is still connecting
+    let result = network.samod(&bob).check_find_document_result(find_cmd);
+    assert!(
+        result.is_none(),
+        "find should still be pending while dialer is connecting"
+    );
+}
+
+#[test]
+fn connected_with_long_handshake_does_not_mark_notfound() {
+    // When a dialer connects in the hub, the status switches to
+    // DialerStatus::Connected, but this doesn't mean the handshake is complete
+    // which means that from the perspective of the document actor, the
+    // connection is not yet ready. We want to make sure we wait until
+    // the handshake is ready before returning NotFound
+    init_logging();
+
+    let mut network = Network::new();
+    let bob = network.create_samod("Bob");
+
+    // Add a dialer — it enters TransportPending immediately
+    let dialer_id = network
+        .samod(&bob)
+        .add_dialer(non_retrying_dialer("wss://sync.example.com"));
+
+    // Start a find for a document that doesn't exist locally
+    let fake_doc_id = DocumentId::new(&mut rand::rng());
+    let find_cmd = network.samod(&bob).begin_find_document(&fake_doc_id);
+
+    // Process events
+    network.run_until_quiescent();
+
+    // Now mark the dialer as connected in the hub, but don't complete the handshake
+    network.samod(&bob).create_dialer_connection(dialer_id);
+
+    // The find should NOT have completed — the dialer is still connecting
+    let result = network.samod(&bob).check_find_document_result(find_cmd);
+    assert!(
+        result.is_none(),
+        "find should still be pending while dialer is connecting"
+    );
+}
+
+/// When a dialer connects and the remote peer has the document, the find
+/// should resolve to Ready. We connect the dialer before issuing find
+/// because in the real runtime the handshake completes within the same
+/// event loop iteration as `create_dialer_connection`, so the document
+/// actor receives `NewConnection` before it can check dialer states.
+#[test]
+fn find_resolves_when_dialer_connects() {
+    init_logging();
+
+    let mut network = Network::new();
+    let alice = network.create_samod("Alice");
+    let bob = network.create_samod("Bob");
+
+    // Alice creates a document with some data
+    let doc_id = create_doc_with_data!(network, alice);
+
+    // Bob adds a dialer and it connects to Alice
+    let dialer_id = network
+        .samod(&bob)
+        .add_dialer(non_retrying_dialer("wss://alice.example.com"));
+    network.connect_with_dialer(bob, dialer_id, alice);
+    network.run_until_quiescent();
+
+    // Now Bob finds the document — should sync from Alice and complete
+    let result = network.samod(&bob).find_document(&doc_id);
+    assert!(
+        result.is_some(),
+        "find should resolve to found after dialer connects"
+    );
+
+    // Verify the document content was synced
+    let bob_ref = network.samod(&bob);
+    let bob_doc = bob_ref.document(&doc_id).unwrap();
+    let val = bob_doc
+        .get(ROOT, "key")
+        .unwrap()
+        .map(|(v, _)| v.to_string())
+        .unwrap_or_default();
+    assert_eq!(val, r#""value""#);
+}
+
+/// When a dialer fails permanently (max retries exhausted), the find should
+/// resolve to NotFound.
+#[test]
+fn find_resolves_to_not_found_when_dialer_fails() {
+    init_logging();
+
+    let mut network = Network::new();
+    let bob = network.create_samod("Bob");
+
+    // Add a dialer with max_retries=0 so it fails permanently on first failure
+    let dialer_id = network
+        .samod(&bob)
+        .add_dialer(non_retrying_dialer("wss://unreachable.example.com"));
+
+    // Start finding a document
+    let fake_doc_id = DocumentId::new(&mut rand::rng());
+    let find_cmd = network.samod(&bob).begin_find_document(&fake_doc_id);
+    network.run_until_quiescent();
+
+    // Find should still be pending
+    let result = network.samod(&bob).check_find_document_result(find_cmd);
+    assert!(
+        result.is_none(),
+        "find should be pending while dialer is connecting"
+    );
+
+    // Dialer fails permanently
+    network
+        .samod(&bob)
+        .dial_failed(dialer_id, "connection refused".to_string());
+    network.run_until_quiescent();
+
+    // Now the find should complete as NotFound
+    let result = network.samod(&bob).check_find_document_result(find_cmd);
+    assert!(
+        matches!(result, Some(None)),
+        "find should resolve to not found after dialer fails: got {result:?}"
+    );
+}
+
+/// A dialer in WaitingToRetry state should NOT block NotFound. WaitingToRetry
+/// means the dialer will try again later, but we don't hold up the find for it.
+#[test]
+fn waiting_to_retry_does_not_block_not_found() {
+    init_logging();
+
+    let mut network = Network::new();
+    let bob = network.create_samod("Bob");
+
+    // Add a dialer that will retry (not capped) with a long delay
+    let dialer_id = network.samod(&bob).add_dialer(DialerConfig {
+        url: url::Url::parse("wss://flaky.example.com").unwrap(),
+        backoff: BackoffConfig {
+            initial_delay: Duration::from_secs(999),
+            max_delay: Duration::from_secs(999),
+            max_retries: None, // will retry indefinitely
+        },
+    });
+
+    // Start finding a document — pending because dialer is connecting
+    let fake_doc_id = DocumentId::new(&mut rand::rng());
+    let find_cmd = network.samod(&bob).begin_find_document(&fake_doc_id);
+    network.run_until_quiescent();
+
+    let result = network.samod(&bob).check_find_document_result(find_cmd);
+    assert!(
+        result.is_none(),
+        "find should be pending while dialer is connecting"
+    );
+
+    // Dialer fails but will retry — transitions to WaitingToRetry
+    network
+        .samod(&bob)
+        .dial_failed(dialer_id, "connection refused".to_string());
+    network.run_until_quiescent();
+
+    // WaitingToRetry should NOT block NotFound
+    let result = network.samod(&bob).check_find_document_result(find_cmd);
+    assert!(
+        matches!(result, Some(None)),
+        "find should resolve to not found when dialer is in WaitingToRetry: got {result:?}"
+    );
+}
+
+/// Removing a dialer while a find is waiting on it should cause the find to
+/// resolve to NotFound (assuming no other connections or connecting dialers).
+#[test]
+fn removing_dialer_while_waiting_triggers_not_found() {
+    init_logging();
+
+    let mut network = Network::new();
+    let bob = network.create_samod("Bob");
+
+    // Add a dialer
+    let dialer_id = network
+        .samod(&bob)
+        .add_dialer(non_retrying_dialer("wss://sync.example.com"));
+
+    // Start finding a document
+    let fake_doc_id = DocumentId::new(&mut rand::rng());
+    let find_cmd = network.samod(&bob).begin_find_document(&fake_doc_id);
+    network.run_until_quiescent();
+
+    // Find should be pending
+    let result = network.samod(&bob).check_find_document_result(find_cmd);
+    assert!(
+        result.is_none(),
+        "find should be pending while dialer exists"
+    );
+
+    // Remove the dialer entirely
+    network.samod(&bob).remove_dialer(dialer_id);
+    network.run_until_quiescent();
+
+    // Find should now complete as NotFound
+    let result = network.samod(&bob).check_find_document_result(find_cmd);
+    assert!(
+        matches!(result, Some(None)),
+        "find should resolve to not found after dialer is removed: got {result:?}"
+    );
+}
+
+/// With multiple dialers, the find should stay pending as long as ANY dialer
+/// is still connecting, even if others have failed.
+#[test]
+fn multiple_dialers_stays_pending_while_any_connecting() {
+    init_logging();
+
+    let mut network = Network::new();
+    let bob = network.create_samod("Bob");
+
+    // Add two dialers
+    let dialer1 = network
+        .samod(&bob)
+        .add_dialer(non_retrying_dialer("wss://server1.example.com"));
+    let _dialer2 = network
+        .samod(&bob)
+        .add_dialer(non_retrying_dialer("wss://server2.example.com"));
+
+    // Start finding a document
+    let fake_doc_id = DocumentId::new(&mut rand::rng());
+    let find_cmd = network.samod(&bob).begin_find_document(&fake_doc_id);
+    network.run_until_quiescent();
+
+    // Find should be pending
+    let result = network.samod(&bob).check_find_document_result(find_cmd);
+    assert!(
+        result.is_none(),
+        "find should be pending with two connecting dialers"
+    );
+
+    // First dialer fails permanently
+    network
+        .samod(&bob)
+        .dial_failed(dialer1, "connection refused".to_string());
+    network.run_until_quiescent();
+
+    // Find should STILL be pending — dialer2 is still connecting
+    let result = network.samod(&bob).check_find_document_result(find_cmd);
+    assert!(
+        result.is_none(),
+        "find should still be pending while second dialer is connecting: got {result:?}"
+    );
+}
+
+/// With multiple dialers, the find should resolve to NotFound only when ALL
+/// connecting dialers have failed.
+#[test]
+fn multiple_dialers_not_found_when_all_fail() {
+    init_logging();
+
+    let mut network = Network::new();
+    let bob = network.create_samod("Bob");
+
+    // Add two dialers
+    let dialer1 = network
+        .samod(&bob)
+        .add_dialer(non_retrying_dialer("wss://server1.example.com"));
+    let dialer2 = network
+        .samod(&bob)
+        .add_dialer(non_retrying_dialer("wss://server2.example.com"));
+
+    // Start finding a document
+    let fake_doc_id = DocumentId::new(&mut rand::rng());
+    let find_cmd = network.samod(&bob).begin_find_document(&fake_doc_id);
+    network.run_until_quiescent();
+
+    // Both dialers fail
+    network
+        .samod(&bob)
+        .dial_failed(dialer1, "connection refused".to_string());
+    network
+        .samod(&bob)
+        .dial_failed(dialer2, "connection refused".to_string());
+    network.run_until_quiescent();
+
+    // Now find should resolve to NotFound
+    let result = network.samod(&bob).check_find_document_result(find_cmd);
+    assert!(
+        matches!(result, Some(None)),
+        "find should resolve to not found when all dialers have failed: got {result:?}"
+    );
+}

--- a/samod-test-harness/src/samod_ref.rs
+++ b/samod-test-harness/src/samod_ref.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 
 use automerge::Automerge;
 use samod_core::{
-    CommandId, ConnectionId, DocumentActorId, DocumentChanged, DocumentId, PeerId, StorageId,
+    CommandId, ConnectionId, DialerId, DocumentActorId, DocumentChanged, DocumentId, PeerId,
+    StorageId,
     actors::{DocumentError, hub::HubEvent},
-    network::{ConnectionEvent, ConnectionInfo, PeerDocState},
+    network::{ConnectionEvent, ConnectionInfo, DialerConfig, PeerDocState},
 };
 
 use crate::samod_id::SamodId;
@@ -114,6 +115,30 @@ impl SamodRef<'_> {
     /// Push an event to the wrapper's inbox (delegates to wrapper).
     pub fn push_event(&mut self, event: HubEvent) {
         self.wrapper().push_event(event)
+    }
+
+    pub fn add_dialer(&mut self, config: DialerConfig) -> DialerId {
+        self.wrapper().add_dialer(config)
+    }
+
+    pub fn create_dialer_connection(&mut self, dialer_id: DialerId) -> ConnectionId {
+        self.wrapper().create_dialer_connection(dialer_id)
+    }
+
+    pub fn dial_failed(&mut self, dialer_id: DialerId, error: String) {
+        self.wrapper().dial_failed(dialer_id, error)
+    }
+
+    pub fn tick(&mut self) {
+        self.wrapper().tick()
+    }
+
+    pub fn remove_dialer(&mut self, dialer_id: DialerId) {
+        self.wrapper().remove_dialer(dialer_id)
+    }
+
+    pub fn handle_events(&mut self) {
+        self.wrapper().handle_events()
     }
 
     pub fn document(&self, doc_id: &DocumentId) -> Option<&Automerge> {


### PR DESCRIPTION
Problem: The logic to determine when a document requires the caller keep track of whether ongoing connections are ready in order to avoid marking a document as not found when we are really just waiting for the network. The reason this happens is that we mark a document as unavailable if all existing connections have said they don't have it, and we don't have it locally. This is annoying because it means that you have to have gates in the application where you do things like "wait for the sync server to be connected" before trying to find a document. 

Solution: now that we have the "dialer" abstraction, we can keep track of the state of a dialer when we are making decisions about if a document is available. This patch modifies the logic so that we don't mark a document as unavailable unless there are no connections that have it _and_ there are no dialers in the process of making a connection (retrying doesn't count). This means that from a users perspective you can now just add a dialer, then call `Repo::find` without having to worry about the state of the network.