### PR TITLE
samod_core: fix a request forwarding bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,11 @@ fn sleep(&self, duration: Duration) -> impl Future<Output = ()> + Send {
   `tungstenite` feature is enabled. This allows using TLS with WebSocket 
   dialers.
 
+### Fixed
+
+* A bug where requests which were forwarded across peers who were configured
+  to not announce documents would fail to resolve on the original requestor
+
 ### Breaking Changes
 
 * **`Repo::connect` / `Connection` removed.** The old unified `connect` method

--- a/samod-core/src/actors/document/doc_state.rs
+++ b/samod-core/src/actors/document/doc_state.rs
@@ -277,6 +277,13 @@ impl DocState {
         };
         tracing::debug!(?connection_id, peer_id=?peer_conn.peer_id, ?msg, "received msg");
 
+        if let SyncMessage::Request { .. } = msg {
+            // Mark the connection as having requested so we know to send them
+            // sync messages in the future, even if we haven't received a sync
+            // message from them yet
+            peer_conn.mark_requested();
+        }
+
         let transition = match &mut self.phase {
             Phase::Loading {
                 pending_sync_messages,

--- a/samod-core/src/actors/document/peer_doc_connection.rs
+++ b/samod-core/src/actors/document/peer_doc_connection.rs
@@ -10,6 +10,10 @@ pub(super) struct PeerDocConnection {
     pub(super) connection_id: ConnectionId,
     pub(super) peer_id: PeerId,
     pub(super) sync_state: sync::State,
+    // Track whether we've ever received a request so that we know whether to
+    // relay the document to the requestor if we obtain the docuemnt after the
+    // request was made
+    pub(super) has_requested: bool,
     // Whether this state has changed since the last pop
     dirty: bool,
     state: PeerDocState,
@@ -31,6 +35,7 @@ impl PeerDocConnection {
             connection_id,
             peer_id,
             sync_state: sync::State::new(),
+            has_requested: false,
             state: PeerDocState::empty(),
             dirty: true,
             announce_policy: AnnouncePolicy::Unknown,
@@ -39,6 +44,17 @@ impl PeerDocConnection {
 
     pub(super) fn reset_sync_state(&mut self) {
         self.sync_state = sync::State::new();
+    }
+
+    pub(super) fn mark_requested(&mut self) {
+        if !self.has_requested {
+            self.has_requested = true;
+            self.dirty = true; // Mark as dirty since the request status changed
+        }
+    }
+
+    pub(super) fn has_requested(&self) -> bool {
+        self.has_requested
     }
 
     pub(super) fn receive_sync_message(

--- a/samod-core/src/actors/document/ready.rs
+++ b/samod-core/src/actors/document/ready.rs
@@ -44,9 +44,13 @@ impl Ready {
         doc: &mut Automerge,
         conn: &mut PeerDocConnection,
     ) -> Option<SyncMessage> {
-        if conn.their_heads().is_none() && conn.announce_policy() != AnnouncePolicy::Announce {
-            // if we haven't received a sync message from them (indicicated by their heads being None)
-            // and the announce policy is set to not announce, then we don't want to send a sync message
+        if conn.their_heads().is_none()
+            && !conn.has_requested()
+            && conn.announce_policy() != AnnouncePolicy::Announce
+        {
+            // if we haven't received a sync message from them, and they don't
+            // already have the document and the announce policy is set to not
+            // announce, then we don't want to send a sync message
             return None;
         }
         conn.generate_sync_message(now, doc)


### PR DESCRIPTION
Problem: when a peer receives a request for a document it does not have  from a peer it is not configured to forward to it will not send a response back to the requesting peer if it later obtains the document from another peer. This manifests as a scenario where the middle peer in a chain of three peers which are configured to not announce will fail to resolve the document for the requesting peer.

Solution: track whether a peer has ever sent a request for a docuemnt and if they have, then when the document is obtained from another peer send a response to the requesting peer.