### PR TITLE
samod-core: fix DontAnnounce policy drops documents synced by clients

### DIFF
--- a/samod-core/src/actors/document/doc_state.rs
+++ b/samod-core/src/actors/document/doc_state.rs
@@ -161,10 +161,18 @@ impl DocState {
         //     .add_on_disk(snapshots.into_keys().chain(incrementals.into_keys()));
         if matches!(self.phase, Phase::Loading { .. }) {
             if self.doc.get_heads().is_empty() {
-                let eligible_conns = peer_connections
+                    // Check if there are pending sync messages from peers that may
+                    // contain the document data. If so, we must process them before
+                    // deciding the document is not found.
+                    let pending_msg_count = if let Phase::Loading { pending_sync_messages } = &self.phase {
+                        pending_sync_messages.values().map(|v| v.len()).sum::<usize>()
+                    } else {
+                        0
+                    };
+                    let eligible_conns = peer_connections
                     .values()
                     .any(|p| p.announce_policy() != AnnouncePolicy::DontAnnounce);
-                if eligible_conns || self.any_dialer_connecting {
+                if eligible_conns || self.any_dialer_connecting || pending_msg_count > 0 {
                     tracing::debug!(
                         eligible_conns,
                         self.any_dialer_connecting,


### PR DESCRIPTION
Fixes #84.

We've cherry-picked the commit from our [repro](https://github.com/cscheid/samod-repro) to target main.

If you have any questions just let us know, thanks!

## Root cause

In `samod-core/src/actors/document/doc_state.rs`, `handle_load()`:

1. Client syncs a new document to the server.
2. The server spawns a document actor in `Loading` phase and queues the client's sync message in `pending_sync_messages`.
3. Two async tasks are dispatched: storage load + announce policy check.
4. Storage load returns empty (document is new, nothing on disk).
5. Announce policy resolves to `DontAnnounce` (the server's policy is `|_, _| false`).
6. `handle_load` checks: `doc.get_heads().is_empty()` is true, and `eligible_conns` (connections with non-`DontAnnounce` policy) is false.
7. **Bug**: transitions to `NotFound`, dropping all `pending_sync_messages` — the client's document data is lost.

The pending sync messages contain the actual document data from the client, but they are never processed.

## Fix

- Before transitioning to `NotFound`, check whether there are pending sync messages. If there are, process them first — they may contain the document data. Only transition to `NotFound` when there are no pending messages AND no eligible connections.

cc. @cscheid 