### PR TITLE
Fix file descriptor explosion

### DIFF
--- a/samod/src/storage/filesystem.rs
+++ b/samod/src/storage/filesystem.rs
@@ -19,10 +19,12 @@ pub fn key_to_path(key: &samod_core::StorageKey) -> std::path::PathBuf {
 pub mod tokio {
     use std::{
         collections::HashMap,
-        path::{Path, PathBuf},
+        path::{Path, PathBuf}, sync::Arc,
     };
 
-    use crate::storage::Storage;
+    use tokio::sync::Semaphore;
+
+use crate::storage::Storage;
 
     use super::key_to_path;
 
@@ -32,12 +34,14 @@ pub mod tokio {
     #[derive(Clone, Debug)]
     pub struct FilesystemStorage {
         data_dir: PathBuf,
+        read_limit: Arc<Semaphore>
     }
 
     impl FilesystemStorage {
         pub fn new<P: AsRef<Path>>(data_dir: P) -> Self {
             Self {
                 data_dir: data_dir.as_ref().to_path_buf(),
+                read_limit: Arc::new(Semaphore::new(500))
             }
         }
 
@@ -81,6 +85,7 @@ pub mod tokio {
                 // Now walk the directory, recursively
                 let mut to_visit = vec![(path, prefix)];
                 while let Some((next_path, key_prefix)) = to_visit.pop() {
+                    let permit = self.read_limit.acquire().await;
                     let mut entries = tokio::fs::read_dir(&next_path).await.unwrap();
                     while let Some(entry) = entries.next_entry().await.unwrap() {
                         let Some(filename) = entry.file_name().to_str().map(|s| s.to_string())
@@ -101,6 +106,7 @@ pub mod tokio {
                             result.insert(next_key_prefix, data);
                         }
                     }
+                    drop(permit);
                 }
                 result
             }


### PR DESCRIPTION
Uses a semaphore to limit the file descriptors able to be opened by a given storage.

Idk if 500 is a sensible number. Maybe it should be more. Maybe we want to allow configuration? 